### PR TITLE
docs(vector): Clarify suggested usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Official Helm charts for Vector. Currently supported:
 - [Vector Agents](charts/vector-agent/README.md) (vector/vector-agent)
 - [Vector Aggregators](charts/vector-aggregator/README.md) (vector/vector-aggregator)
 
+*Note*: The [helm charts in the `vector` repository](https://github.com/vectordotdev/vector/tree/master/distribution/helm) are being deprecated in favor of the ones here. In addition, consider trying out the experimental [Vector chart](charts/vector/README.md) for your deployment!
+
 # How to use the Vector Helm Repository
 
 You need to add this repository to your Helm repositories:


### PR DESCRIPTION
These charts used to be hosted within the main repo, and #24 added a combined chart that looks to be the future. This adds a (likely short-term) pointer in the README to help guide folks to the right path.

Maybe most importantly, please consider this a strawman since I'm not entirely certain this is the chart y'all recommend folks use!

This is related to https://github.com/vectordotdev/vector/pull/9396