### PR TITLE
fix(vector): Fix ordering of `default` function in port helpers

### DIFF
--- a/charts/vector/ci/dupe-ports-values.yaml
+++ b/charts/vector/ci/dupe-ports-values.yaml
@@ -1,0 +1,18 @@
+# Components sharing the same port with different protocols 
+## Values file for testing config that shares the same numeric port. 
+customConfig:
+  api:
+    enabled: false
+  sources:
+    syslog-tcp:
+      type: syslog
+      address: 0.0.0.0:514
+      max_length: 102400
+      mode: tcp
+      shutdown_timeout_secs: 30
+    syslog-udp:
+      type: syslog
+      address: 0.0.0.0:514
+      max_length: 102400
+      mode: udp
+      shutdown_timeout_secs: 30

--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -102,7 +102,7 @@ Generate a single ServicePort based on a component configuration
 {{- $name := index . 0 | kebabcase -}}
 {{- $config := index . 1 -}}
 {{- $port := mustRegexFind "[0-9]+$" (get $config "address") -}}
-{{- $protocol := default (get $config "mode" | upper) "TCP" }}
+{{- $protocol := default "TCP" (get $config "mode" | upper) }}
 - name: {{ $name }}
   port: {{ $port }}
   protocol: {{ $protocol }}
@@ -146,7 +146,7 @@ Generate a single ContainerPort based on a component configuration
 {{- $name := index . 0 | kebabcase -}}
 {{- $config := index . 1 -}}
 {{- $port := mustRegexFind "[0-9]+$" (get $config "address") -}}
-{{- $protocol := default (get $config "mode" | upper) "TCP" }}
+{{- $protocol := default "TCP" (get $config "mode" | upper) }}
 - name: {{ $name | trunc 15 | trimSuffix "-" }}
   containerPort: {{ $port }}
   protocol: {{ $protocol }}


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #77
