### PR TITLE
feat(vector)!: Update secrets.generic to take unencoded values

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.1.0-alpha.4"
+version: "0.1.0-beta.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.1.0-alpha.4](https://img.shields.io/badge/Version-0.1.0--alpha.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.16.1--distroless--libc-informational?style=flat-square)
+![Version: 0.1.0-beta.0](https://img.shields.io/badge/Version-0.1.0--beta.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.16.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -140,7 +140,7 @@ helm install --name <RELEASE_NAME> \
 | resources | object | `{}` | Set Vector resource requests and limits. |
 | role | string | `"Aggregator"` | Role for this Vector (possible values: Agent, Aggregator, Stateless-Aggregator) |
 | rollWorkload | bool | `true` | Add a checksum of the generated ConfigMap to workload annotations |
-| secrets.generic | object | `{}` | Each Key/Value will be added to the Secret's data key |
+| secrets.generic | object | `{}` | Each Key/Value will be added to the Secret's data key, each value should be raw and NOT base64 encoded |
 | securityContext | object | `{}` | Specify securityContext on Vector containers |
 | service.annotations | object | `{}` | Set annotations on Vector's Service |
 | service.enabled | bool | `true` | If true, create and use a Service resource |

--- a/charts/vector/templates/secret.yaml
+++ b/charts/vector/templates/secret.yaml
@@ -8,6 +8,6 @@ metadata:
 type: Opaque
 data:
 {{- range $key, $value := $.Values.secrets.generic }}
-  {{ $key }}: {{ $value | quote }}
+  {{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -45,12 +45,11 @@ podManagementPolicy: OrderedReady
 
 ## Create a Secret resource for Vector to use
 secrets:
-  # secrets.generic -- Each Key/Value will be added to the Secret's data key
-  ## Values should be entered base64 encoded (examples below are "REPLACE_ME" encoded)
+  # secrets.generic -- Each Key/Value will be added to the Secret's data key, each value should be raw and NOT base64 encoded
   ## NOTE: Don't commit unencrypted secrets to git!
   generic: {}
-    # awsAccessKeyId: "UkVQTEFDRV9NRQo="
-    # awsSecretAccessKey: "UkVQTEFDRV9NRQo="
+    # awsAccessKeyId: "access-key"
+    # awsSecretAccessKey: "secret-access-key"
 
 ## Configure a HorizontalPodAutoscaler for Vector
 ## Valid for Stateless-Aggregator role


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #72

This change aligns us with [Datadog's chart](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/secret-api-key.yaml#L11)
