### PR TITLE
fix(vector): Toggle both service and headless service with service.enabled

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.1.0-beta.2](https://img.shields.io/badge/Version-0.1.0--beta.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.3-distroless-libc](https://img.shields.io/badge/AppVersion-0.17.3--distroless--libc-informational?style=flat-square)
+![Version: 0.1.0-beta.3](https://img.shields.io/badge/Version-0.1.0--beta.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.3-distroless-libc](https://img.shields.io/badge/AppVersion-0.17.3--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 
@@ -140,7 +140,7 @@ helm install --name <RELEASE_NAME> \
 | persistence.size | string | `"10Gi"` | Specifies the size of PersistentVolumeClaims |
 | podAnnotations | object | `{}` | Set annotations on Vector Pods |
 | podDisruptionBudget.enabled | bool | `false` | Enable a PodDisruptionBudget for Vector |
-| podDisruptionBudget.maxUnavailable | int | `1` | The number of Pods that can be unavailable after an eviction |
+| podDisruptionBudget.maxUnavailable | string | `nil` | The number of Pods that can be unavailable after an eviction |
 | podDisruptionBudget.minAvailable | int | `1` | The number of Pods that must still be available after an eviction |
 | podLabels | object | `{}` | Set labels on Vector Pods |
 | podManagementPolicy | string | `"OrderedReady"` | Specify the podManagementPolicy for the Aggregator role |

--- a/charts/vector/templates/service-headless.yaml
+++ b/charts/vector/templates/service-headless.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.service.enabled }}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/vector/templates/service-headless.yaml
+++ b/charts/vector/templates/service-headless.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.role "Aggregator") (eq .Values.role "Stateless-Aggregator") -}}
+{{- if and .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/vector/templates/service.yaml
+++ b/charts/vector/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.service.enabled }}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #100

This mirrors the condition used for both the service and service-headless.
Headless services are generally more useful for load balancing or being able
to select specific instances from a StatefulSet, but rather than introducing
more configuration this seems simpler unless a user requests more specific options.
