### PR TITLE
docs(vector): Handle helm-docs processing of vector template example

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.1.0"
+version: "0.1.1"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.3-distroless-libc](https://img.shields.io/badge/AppVersion-0.17.3--distroless--libc-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.3-distroless-libc](https://img.shields.io/badge/AppVersion-0.17.3--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -102,9 +102,9 @@ customConfig:
       labels:
         foo: bar
         host: |
-          {{ host }}
+          {{ print "{{ host }}" }}
         source: |
-          {{ source_type }}
+          {{ print "{{ source_type }}" }}
 ```
 
 ## All configuration options

--- a/charts/vector/README.md.gotmpl
+++ b/charts/vector/README.md.gotmpl
@@ -100,9 +100,9 @@ customConfig:
       labels:
         foo: bar
         host: |
-          {{ print "{{ host }}" }}
+          {{ print "{{ print \"{{ host }}\" }}" }}
         source: |
-          {{ print "{{ source_type }}" }}
+          {{ print "{{ print \"{{ source_type }}\" }}" }}
 ```
 
 ## All configuration options


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #106

Fun issue - similar to why it breaks when templated through Helm, helm-docs templating is also processing go template functions here. I resolved by just doing the same thing _again_, instructing the template engine to print the entire string.
