### PR TITLE
fix(vector): typo `podPriorityClassName` & `StatefulSet`

### DIFF
--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -7,7 +7,7 @@ serviceAccountName: {{ include "vector.serviceAccountName" . }}
 securityContext:
 {{ toYaml . | indent 2 }}
 {{- end }}
-{{- with .Values.priorityClassName }}
+{{- with .Values.podPriorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
 {{- with .Values.dnsPolicy }}

--- a/charts/vector/templates/hpa.yaml
+++ b/charts/vector/templates/hpa.yaml
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     {{- if (eq .Values.role "Aggregator") }}
-    kind: Statefulset
+    kind: StatefulSet
     {{- else if (eq .Values.role "Stateless-Aggregator") }}
     kind: Deployment
     {{- end }}


### PR DESCRIPTION
fix two typo:

* Use `podPriorityClassName` in values just like before in `_pod.tpl`
* Not `Statefulset`, is `StatefulSet` in hpa.yml (it also cause some error).

```
Events:
  Type     Reason          Age                   From                       Message
  ----     ------          ----                  ----                       -------
  Warning  FailedGetScale  2m5s (x275 over 72m)  horizontal-pod-autoscaler  no matches for kind "Statefulset" in group "apps"
  ```