### PR TITLE
fix(vector-aggregator): Fix the conditions for enable/disable SA on the HAProxy

### DIFF
--- a/charts/vector-aggregator/Chart.yaml
+++ b/charts/vector-aggregator/Chart.yaml
@@ -3,7 +3,7 @@ name: vector-aggregator
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart to aggregate data with Vector
-version: "0.19.0"
+version: "0.20.0"
 appVersion: "0.18.0"
 home: https://vector.dev/
 sources:

--- a/charts/vector-aggregator/templates/haproxy/deployment.yaml
+++ b/charts/vector-aggregator/templates/haproxy/deployment.yaml
@@ -27,7 +27,9 @@ spec:
 {{ toYaml .Values.haproxy.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.haproxy.serviceAccount.create }}
       serviceAccountName: {{ include "libvector.serviceAccountName" . }}-haproxy
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.haproxy.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.haproxy.podSecurityContext | nindent 8 }}

--- a/charts/vector-aggregator/templates/haproxy/deployment.yaml
+++ b/charts/vector-aggregator/templates/haproxy/deployment.yaml
@@ -27,9 +27,7 @@ spec:
 {{ toYaml .Values.haproxy.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-    {{- if .Values.haproxy.serviceAccount.create }}
-      serviceAccountName: {{ include "libvector.serviceAccountName" . }}-haproxy
-    {{- end }}
+      serviceAccountName: {{ include "haproxy.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.haproxy.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.haproxy.podSecurityContext | nindent 8 }}

--- a/charts/vector-aggregator/templates/haproxy/serviceaccount.yaml
+++ b/charts/vector-aggregator/templates/haproxy/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.haproxy.enabled .Values.serviceAccount.create -}}
+{{- if and .Values.haproxy.enabled .Values.haproxy.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
This PR fix the 'if' condition in the serviceaccount.yaml file for use only the value in haproxy block in the value file (haproxy.serviceAccount.create).

And add a condition 'if' in the deployment of haproxy for add or remove the annotation 'serviceAccount' if the value is 'haproxy.serviceAccount.create' is true or false.

If I understood correctly, the SA is only used for the PSP and it is deprecated from version v1.21.