### PR TITLE
chore: Deprecate old Vector Agent/Aggregator/Shared charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Official Helm charts for Vector. Currently supported:
 - [Vector](charts/vector/README.md) (vector/vector)
-- *DEPRECATED* [Vector Agents](charts/vector-agent/README.md) (vector/vector-agent)
-- *DEPRECATED* [Vector Aggregators](charts/vector-aggregator/README.md) (vector/vector-aggregator)
+- **DEPRECATED** [Vector Agents](charts/vector-agent/README.md) (vector/vector-agent)
+- **DEPRECATED** [Vector Aggregators](charts/vector-aggregator/README.md) (vector/vector-aggregator)
 
 # How to use the Vector Helm Repository
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 Official Helm charts for Vector. Currently supported:
 - [Vector](charts/vector/README.md) (vector/vector)
-- [Vector Agents](charts/vector-agent/README.md) (vector/vector-agent)
-- [Vector Aggregators](charts/vector-aggregator/README.md) (vector/vector-aggregator)
-
-*Note*: The [helm charts in the `vector` repository](https://github.com/vectordotdev/vector/tree/master/distribution/helm) are being deprecated in favor of the ones here. In addition, consider trying out the experimental [Vector chart](charts/vector/README.md) for your deployment!
+- *DEPRECATED* [Vector Agents](charts/vector-agent/README.md) (vector/vector-agent)
+- *DEPRECATED* [Vector Aggregators](charts/vector-aggregator/README.md) (vector/vector-aggregator)
 
 # How to use the Vector Helm Repository
 

--- a/charts/vector-agent/Chart.yaml
+++ b/charts/vector-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: vector-agent
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart to collect Kubernetes logs with Vector
-version: "0.20.0"
+version: "0.21.0"
 appVersion: "0.19.0"
 home: https://vector.dev/
 sources:
@@ -15,3 +15,4 @@ dependencies:
   - name: vector-shared
     version: "~0.1.0"
     repository: https://helm.vector.dev
+deprecated: true

--- a/charts/vector-agent/Chart.yaml
+++ b/charts/vector-agent/Chart.yaml
@@ -8,9 +8,9 @@ appVersion: "0.19.0"
 home: https://vector.dev/
 sources:
   - https://github.com/timberio/vector/
-maintainers:
-  - name: Datadog
-    email: team-vector@datadoghq.com
+# maintainers:
+#   - name: Datadog
+#     email: team-vector@datadoghq.com
 dependencies:
   - name: vector-shared
     version: "~0.1.0"

--- a/charts/vector-aggregator/Chart.yaml
+++ b/charts/vector-aggregator/Chart.yaml
@@ -3,7 +3,7 @@ name: vector-aggregator
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart to aggregate data with Vector
-version: "0.20.0"
+version: "0.21.0"
 appVersion: "0.19.0"
 home: https://vector.dev/
 sources:
@@ -15,3 +15,4 @@ dependencies:
   - name: vector-shared
     version: "~0.1.0"
     repository: https://helm.vector.dev
+deprecated: true

--- a/charts/vector-aggregator/Chart.yaml
+++ b/charts/vector-aggregator/Chart.yaml
@@ -8,9 +8,9 @@ appVersion: "0.19.0"
 home: https://vector.dev/
 sources:
   - https://github.com/timberio/vector/
-maintainers:
-  - name: Datadog
-    email: team-vector@datadoghq.com
+# maintainers:
+#   - name: Datadog
+#     email: team-vector@datadoghq.com
 dependencies:
   - name: vector-shared
     version: "~0.1.0"

--- a/charts/vector-shared/Chart.yaml
+++ b/charts/vector-shared/Chart.yaml
@@ -7,7 +7,7 @@ version: "0.2.0"
 home: https://vector.dev/
 sources:
   - https://github.com/timberio/vector/
-maintainers:
-  - name: Datadog
-    email: team-vector@datadoghq.com
+# maintainers:
+#   - name: Datadog
+#     email: team-vector@datadoghq.com
 deprecated: true

--- a/charts/vector-shared/Chart.yaml
+++ b/charts/vector-shared/Chart.yaml
@@ -3,10 +3,11 @@ name: vector-shared
 type: library
 icon: https://vector.dev/press/vector-icon.svg
 description: Shared dependencies of Vector Helm charts
-version: "0.1.0"
+version: "0.2.0"
 home: https://vector.dev/
 sources:
   - https://github.com/timberio/vector/
 maintainers:
   - name: Datadog
     email: team-vector@datadoghq.com
+deprecated: true


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>
