### PR TITLE
feat(vector): Add honorLabels and honorTimestamps to PodMonitor

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.4.0"
+version: "0.5.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.19.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.19.0--distroless--libc-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.19.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.19.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 
@@ -171,6 +171,8 @@ helm install --name <RELEASE_NAME> \
 | podManagementPolicy | string | `"OrderedReady"` | Specify the podManagementPolicy for the Aggregator role |
 | podMonitor.additionalLabels | object | `{}` | Adds additional labels to the PodMonitor |
 | podMonitor.enabled | bool | `false` | If true, create a PodMonitor for Vector |
+| podMonitor.honorLabels | bool | `false` |  |
+| podMonitor.honorTimestamps | bool | `true` |  |
 | podMonitor.jobLabel | string | `"app.kubernetes.io/name"` | Override the label to retrieve the job name from |
 | podMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
 | podMonitor.path | string | `"/metrics"` | Override the path to scrape |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -171,8 +171,8 @@ helm install --name <RELEASE_NAME> \
 | podManagementPolicy | string | `"OrderedReady"` | Specify the podManagementPolicy for the Aggregator role |
 | podMonitor.additionalLabels | object | `{}` | Adds additional labels to the PodMonitor |
 | podMonitor.enabled | bool | `false` | If true, create a PodMonitor for Vector |
-| podMonitor.honorLabels | bool | `false` |  |
-| podMonitor.honorTimestamps | bool | `true` |  |
+| podMonitor.honorLabels | bool | `false` | If true, honor_labels is set to true in scrape config |
+| podMonitor.honorTimestamps | bool | `true` | If true, honor_timestamps is set to true in scrape config |
 | podMonitor.jobLabel | string | `"app.kubernetes.io/name"` | Override the label to retrieve the job name from |
 | podMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
 | podMonitor.path | string | `"/metrics"` | Override the path to scrape |

--- a/charts/vector/templates/podmonitor.yaml
+++ b/charts/vector/templates/podmonitor.yaml
@@ -19,6 +19,8 @@ spec:
   podMetricsEndpoints:
     - port: {{ .Values.podMonitor.port }}
       path: {{ .Values.podMonitor.path }}
+      honorLabels: {{ .Values.podMonitor.honorLabels }}
+      honorTimestamps: {{ .Values.podMonitor.honorTimestamps }}
       {{- with .Values.podMonitor.relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -345,6 +345,10 @@ podMonitor:
   metricRelabelings: []
   # podMonitor.additionalLabels -- Adds additional labels to the PodMonitor
   additionalLabels: {}
+  # podmonitor.honorLabels -- Set if honor_labels should be set for scape config https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
+  honorLabels: false
+  # podmonitor.honorTimestamps -- Set if honor_timestamps should be set for scape config https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
+  honorTimestamps: true
 
 ## Optional built-in HAProxy load balancer
 haproxy:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -345,9 +345,11 @@ podMonitor:
   metricRelabelings: []
   # podMonitor.additionalLabels -- Adds additional labels to the PodMonitor
   additionalLabels: {}
-  # podmonitor.honorLabels -- Set if honor_labels should be set for scape config https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
+  # podmonitor.honorLabels -- If true, honor_labels is set to true in scrape config
+  ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
   honorLabels: false
-  # podmonitor.honorTimestamps -- Set if honor_timestamps should be set for scape config https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
+  # podmonitor.honorTimestamps -- If true, honor_timestamps is set to true in scrape config
+  ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
   honorTimestamps: true
 
 ## Optional built-in HAProxy load balancer

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -345,10 +345,10 @@ podMonitor:
   metricRelabelings: []
   # podMonitor.additionalLabels -- Adds additional labels to the PodMonitor
   additionalLabels: {}
-  # podmonitor.honorLabels -- If true, honor_labels is set to true in scrape config
+  # podMonitor.honorLabels -- If true, honor_labels is set to true in scrape config
   ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
   honorLabels: false
-  # podmonitor.honorTimestamps -- If true, honor_timestamps is set to true in scrape config
+  # podMonitor.honorTimestamps -- If true, honor_timestamps is set to true in scrape config
   ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
   honorTimestamps: true
 


### PR DESCRIPTION
Add ability to set honorLabels and honorTimestamps for the PodMonitor which can be deployed with the vector helm chart. Fixes #152