### PR TITLE
docs(vector): Fix loki label ends with new line

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -101,9 +101,9 @@ customConfig:
       #...
       labels:
         foo: bar
-        host: |
+        host: |-
           {{ print "{{ host }}" }}
-        source: |
+        source: |-
           {{ print "{{ source_type }}" }}
 ```
 

--- a/charts/vector/README.md.gotmpl
+++ b/charts/vector/README.md.gotmpl
@@ -99,9 +99,9 @@ customConfig:
       #...
       labels:
         foo: bar
-        host: |
+        host: |-
           {{ print "{{ print \"{{ host }}\" }}" }}
-        source: |
+        source: |-
           {{ print "{{ print \"{{ source_type }}\" }}" }}
 ```
 


### PR DESCRIPTION
Hi

The current example generates Loki labels ending with a newline. This fixes it