### PR TITLE
Release vector-0.7.0-rc.0

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -52,3 +52,4 @@ commit_parsers = [
 filter_commits = true
 # glob pattern for matching git tags
 tag_pattern = "vector-*"
+date_order = true

--- a/.github/release-changelog.sh
+++ b/.github/release-changelog.sh
@@ -6,4 +6,4 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 set -x
 
 _chart_version=$(yq eval .version "charts/vector/Chart.yaml")
-git cliff --config .github/cliff.toml -t "vector-$_chart_version" -p CHANGELOG.md -u
+git cliff --config .github/cliff.toml --tag "vector-$_chart_version" --prepend CHANGELOG.md --unreleased

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       charts: ${{ steps.list-changed.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up chart-testing
@@ -38,7 +38,7 @@ jobs:
       - changed
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up chart-testing
@@ -52,7 +52,7 @@ jobs:
       - changed
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Run helm-docs
@@ -76,7 +76,7 @@ jobs:
           - v1.19.11
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Add vector helm repo
@@ -108,7 +108,7 @@ jobs:
           - v1.19.11
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Create kind ${{ matrix.k8s }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Configure Git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [vector-0.7.0-rc.0] - 2022-03-08
+
+### Vector
+
+#### Features
+
+- Add list verb for upcoming kube-rs change ([e390ead](https://github.com/vectordotdev/helm-charts/commit/e390ead62dcc5e2736d9fb7cb1f19ac7684f3d92))
+
 ## [vector-0.6.0] - 2022-02-11
 
 ### Vector

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.6.0"
+version: "0.7.0-rc.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -29,4 +29,4 @@ annotations:
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/vectordotdev/helm-charts
-  artifacthub.io/prerelease: "false"
+  artifacthub.io/prerelease: "true"

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.20.0--distroless--libc-informational?style=flat-square)
+![Version: 0.7.0-rc.0](https://img.shields.io/badge/Version-0.7.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.20.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/templates/rbac.yaml
+++ b/charts/vector/templates/rbac.yaml
@@ -14,6 +14,7 @@ rules:
       - namespaces
       - pods
     verbs:
+      - list
       - watch
 {{- if and .Values.psp.create (.Capabilities.APIVersions.Has "policy/v1beta1") }}
   - apiGroups:


### PR DESCRIPTION
Adds needed RBAC changes for the ongoing `kube` work in Vector, I will update CI to use pre-release versions until we get everything merged in.