### PR TITLE
Autoscale across AZs by default

### DIFF
--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -178,7 +178,19 @@ tolerations: []
 
 # affinity -- Allow Vector to schedule using affinity rules
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-affinity: {}
+affinity:
+  ## Scale across different AZs by default.
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - vector
+          topologyKey: topology.kubernetes.io/zone
 
 ## Configuration for Vector's Service
 service:


### PR DESCRIPTION
I get a feeling that this won't be enough, but this can at least prompt some discussion on what the right way to go is.

Recent customer deployments have shown that this would be reasonable to use by default, since it's what folks doing production deployments are going to want anyways and I've had to copy/paste this snippet a few times.