### PR TITLE
fix(vector): update app.kubernetes.io/version to be the image.tag if it is set.

### DIFF
--- a/charts/vector-shared/templates/_labels.tpl
+++ b/charts/vector-shared/templates/_labels.tpl
@@ -7,7 +7,7 @@ Common labels.
 helm.sh/chart: {{ include "libvector.chart" . }}
 {{ include "libvector.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ include "libvector.name" . }}

--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "vector.chart" . }}
 {{ include "vector.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ with .Values.commonLabels }}

--- a/charts/vector/templates/haproxy/_helpers.tpl
+++ b/charts/vector/templates/haproxy/_helpers.tpl
@@ -14,7 +14,7 @@ Common labels
 helm.sh/chart: {{ include "vector.chart" . }}
 {{ include "haproxy.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}


### PR DESCRIPTION
Closes #174 

This updates the `app.kubernetes.io/version` field to be `.Values.image.tag` if it has been set.

I have made this change everywhere, including in the haproxy templates. Let me know if that is too much!

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>