### PR TITLE
chore: release version 0.9.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,8 @@ jobs:
           fetch-depth: 0
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
+      - name: Copy example values into ci/
+        run: cp charts/vector/examples/*-values.yaml charts/vector/ci/
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
 
@@ -114,6 +116,8 @@ jobs:
           node_image: kindest/node:${{ matrix.k8s }}
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
+      - name: Copy example values into ci/
+        run: cp charts/vector/examples/*-values.yaml charts/vector/ci/
       - name: Run chart-testing (install)
         run: ct install --config .github/ct.yaml --excluded-charts vector-shared --upgrade
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,6 @@ jobs:
           helm repo add vector https://helm.vector.dev
           helm repo update
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [vector-0.9.0] - 2022-04-12
+
+### Vector
+
+#### Bug Fixes
+
+- Bump Vector to v0.20.1 ([8a03f17](https://github.com/vectordotdev/helm-charts/commit/8a03f1728c1007b02e8ad6e029a41bb01d1f2d8d))
+
+#### Documentation
+
+- Add quickstart values and docs (#176) ([ce17ab6](https://github.com/vectordotdev/helm-charts/commit/ce17ab665824768634fa1cab0c31d8b3b3e97b0e))
+
+#### Features
+
+- Improve help text printed by NOTES.txt and reduce duplication of internal templates (#189) ([e5d994c](https://github.com/vectordotdev/helm-charts/commit/e5d994c84a74be029061c55caa986d913b2f060a))
+- Add help output for configurations with datadog_agent source (#178) ([13aadfb](https://github.com/vectordotdev/helm-charts/commit/13aadfb10163fa7c36698acd9a492b4023d73a7b))
+
 ## [vector-0.7.0] - 2022-03-23
 
 ### Vector

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -29,4 +29,4 @@ annotations:
   artifacthub.io/links: |
     - name: Chart Source
       url: https://github.com/vectordotdev/helm-charts
-  artifacthub.io/prerelease: "true"
+  artifacthub.io/prerelease: "false"

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.7.0"
+version: "0.8.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.8.0"
+version: "0.9.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application
@@ -18,11 +18,11 @@ maintainers:
   - name: Datadog
     email: vector@datadoghq.com
 icon: https://vector.dev/press/vector-icon.svg
-appVersion: "0.20.0-distroless-libc"
+appVersion: "0.20.1-distroless-libc"
 annotations:
   artifacthub.io/images: |
     - name: vector
-      image: timberio/vector:0.20.0-distroless-libc
+      image: timberio/vector:0.20.1-distroless-libc
     - name: haproxy
       image: haproxytech/haproxy-alpine:2.4.4
   artifacthub.io/license: MPL-2.0

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.20.0--distroless--libc-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.20.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.20.0--distroless--libc-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.20.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/docs/quickstart.md
+++ b/charts/vector/docs/quickstart.md
@@ -1,0 +1,174 @@
+# Quickstart
+
+In this quickstart guide, we will walk you through installing Vector with Helm
+for a variety of common platforms and tools.
+
+_NOTE: The instructions here assume the use of Helm v3, and Bash._
+
+## Getting started with Datadog
+
+### Prerequisites
+
+Verify you have `helm` and `kubectl` installed locally to proceed. `helm` should
+be `v3.0+`.
+
+```bash
+helm version
+```
+
+Ensure you have both the Datadog and Vector charts, and they are up to date.
+
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo add vector https://helm.vector.dev
+helm repo update
+```
+
+Access to a pre-existing Kubernetes cluster, or start a new cluster locally
+with `minikube`.
+
+```bash
+minikube start
+minikube addons enable metrics-server
+minikube status
+```
+
+Clone this repository locally to have access to the quickstart values files.
+
+```bash
+git clone https://github.com/vectordotdev/helm-charts.git && \
+	cd helm-charts/charts/vector
+```
+
+### Installing
+
+Export your Datadog API key into your local environment.
+
+```bash
+export DATADOG_API_KEY="<REPLACE_ME>"
+```
+
+Then install Vector into its own namespace, providing your API key as an
+environment variable.
+
+```bash
+helm install vector vector/vector --namespace vector --create-namespace \
+	--values examples/datadog-values.yaml  --set secrets.generic.datadog_api_key="${DATADOG_API_KEY}"
+```
+
+Run the next command to confirm Vector has been configured properly and can
+connect to your Datadog account.
+
+```bash
+kubectl logs statefulset/vector --namespace vector --follow
+```
+
+Running the above will tail Vector's logs and allow to confirm your API key
+is correct. In the logs you should only see INFO messages, and the following
+logs (one for each configured sink):
+
+```json
+{"timestamp":"2022-03-30T20:25:48.016522Z","level":"INFO","message":"Healthcheck: Passed.","target":"vector::topology::builder"}
+{"timestamp":"2022-03-30T20:25:48.024391Z","level":"INFO","message":"Healthcheck: Passed.","target":"vector::topology::builder"}
+```
+
+Once Vector has been installed and configured, you can install your Datadog Agents.
+By default the Agents will forward their logs and metrics directly to Datadog's
+hosted intake, we'll create a values file to override that behavior to forward to
+your new Vector Aggregators.
+
+For Datadog Agents version `7.35`/`6.35` or greater:
+
+```bash
+cat <<-'VALUES' > dd-agent.yaml
+---
+datadog:
+  logs:
+    enabled: true
+    containerCollectAll: true
+agents:
+  useConfigMap: true
+  customAgentConfig:
+    # NOTE: If you're using a quickstart environment like `minikube`,
+    # uncomment the line below; otherwise, we recommend leaving it with the
+    # default setting of `true`.
+    # kubelet_tls_verify: false
+    vector:
+      logs:
+        enabled: true
+	# Use https if SSL is enabled in Vector source configuration
+        url: http://vector-haproxy.vector:8282
+      metrics:
+        enabled: true
+	# Use https if SSL is enabled in Vector source configuration
+        url: http://vector-haproxy.vector:8282
+VALUES
+```
+
+For Datadog Agents version `7.34`/`6.34` and older:
+
+_NOTE: Metrics will not be routed through Vector for Datadog Agent versions older
+than `7.35`/`6.35`._
+
+```bash
+cat <<-'VALUES' > dd-agent.yaml
+---
+datadog:
+  logs:
+    enabled: true
+    containerCollectAll: true
+agents:
+  useConfigMap: true
+  customAgentConfig:
+    # NOTE: If you're using a quickstart environment like `minikube`,
+    # uncomment the line below; otherwise, we recommend leaving it with the
+    # default setting of `true`.
+    # kubelet_tls_verify: false
+    logs_config:
+      logs_dd_url: vector-haproxy.vector:8282
+      # Set to false if SSL is enabled in Vector source configuration
+      logs_no_ssl: true
+      use_http: true
+VALUES
+```
+
+_NOTE: When you have the `datadog_agent` source configured, a `helm install` or
+`helm upgrade` will output the appropriate values to provide to the datadog helm
+chart._
+
+```bash
+helm install datadog datadog/datadog --namespace datadog --create-namespace \
+	--values dd-agent.yaml --set datadog.apiKey="${DATADOG_API_KEY}"
+```
+
+Once the Datadog Agents are running you should be able to see your logs in
+Datadog's [Live Tail](https://app.datadoghq.com/logs/livetail?query=sender%3Avector) view,
+by filtering for `sender:vector`. You can also use `vector top` to view Vector's
+topology and related metrics:
+
+```bash
+kubectl --namespace vector exec --stdin --tty statefulset/vector -- vector top
+```
+
+### Troubleshooting
+
+To diagnose problems the following commands may prove useful:
+
+For Datadog Agents:
+
+```bash
+kubectl --namespace datadog exec --stdin --tty daemonset/datadog -- agent status
+```
+
+For the HAProxy:
+
+```bash
+kubectl --namespace vector logs --follow deployment/vector-haproxy
+```
+
+For the Vector Aggregators:
+
+```bash
+kubectl --namespace vector exec --stdin --tty statefulset/vector -- vector tap internal_logs
+```
+

--- a/charts/vector/examples/datadog-values.yaml
+++ b/charts/vector/examples/datadog-values.yaml
@@ -1,0 +1,181 @@
+## See Vector helm documentation to learn more:
+## https://vector.dev/docs/setup/installation/package-managers/helm/
+
+# nameOverride -- Override name of app
+fullnameOverride: vector
+
+## Create a Secret resource for Vector to use
+secrets:
+  # secrets.generic -- Each Key/Value will be added to the Secret's data key, each value should be raw and NOT base64 encoded
+  ## Any secrets can be provided here, it's commonly used for credentials and other access related values.
+  ## NOTE: Don't commit unencrypted secrets to git!
+  generic:
+    datadog_api_key: "REPLACE_ME"
+
+## Configure a HorizontalPodAutoscaler for Vector
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  ## The provided HAProxy config is limited to 10 backends
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# env -- Set environment variables in Vector containers
+## The examples below leverage examples from secrets.generic and assume no name overrides with a Release name of "vector"
+env:
+  - name: DATADOG_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: vector
+        key: datadog_api_key
+  - name: VECTOR_LOG_FORMAT
+    value: json
+
+# resources -- Set Vector resource requests and limits.
+resources:
+  ## Required for HPA to function
+  requests:
+    cpu: 1000m
+    memory: 512Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 256Mi
+
+# affinity -- Allow Vector to schedule using affinity rules
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity:
+  ## Scale across different AZs by default.
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - vector
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - Aggregator
+          topologyKey: topology.kubernetes.io/zone
+
+# customConfig -- Override Vector's default configs, if used **all** options need to be specified
+## This section supports using helm templates to populate dynamic values
+## Ref: https://vector.dev/docs/reference/configuration/
+customConfig:
+  data_dir: /vector-data-dir
+  api:
+    enabled: true
+    address: 0.0.0.0:8686
+    playground: false
+  sources:
+    datadog_agent:
+      address: 0.0.0.0:8282
+      type: datadog_agent
+      multiple_outputs: true
+    internal_metrics:
+      type: internal_metrics
+  transforms:
+    remap_logs:
+      type: remap
+      inputs:
+        - datadog_agent.logs
+      source: |
+        # Parse the received .ddtags field so we can more easily access the contained tags
+        .ddtags = parse_key_value!(.ddtags, key_value_delimiter: ":", field_delimiter: ",")
+        .ddtags.sender = "vector"
+        .ddtags.vector_aggregator = get_hostname!()
+        # Re-encode Datadog tags as a string for the `datadog_logs` sink
+        .ddtags = encode_key_value(.ddtags, key_value_delimiter: ":", field_delimiter: ",")
+
+        # Datadog Agents pass a "status" field that is stripped when ingested
+        del(.status)
+  sinks:
+    datadog_logs:
+      type: datadog_logs
+      inputs:
+        - remap_logs
+      default_api_key: ${DATADOG_API_KEY}
+      compression: gzip
+    datadog_metrics:
+      type: datadog_metrics
+      inputs:
+        - datadog_agent.metrics
+        - internal_metrics
+      default_api_key: ${DATADOG_API_KEY}
+    # TODO: soon!
+    # datadog_traces:
+    #   type: datadog_traces
+
+# livenessProbe -- Override default liveness probe settings, if customConfig is used requires customConfig.api.enabled true
+## Requires Vector's API to be enabled
+livenessProbe:
+  httpGet:
+    path: /health
+    port: api
+
+# readinessProbe -- Override default readiness probe settings, if customConfig is used requires customConfig.api.enabled true
+## Requires Vector's API to be enabled
+readinessProbe:
+  httpGet:
+    path: /health
+    port: api
+
+## Optional built-in HAProxy load balancer
+haproxy:
+  # haproxy.enabled -- If true, create a HAProxy load balancer
+  enabled: true
+
+  # haproxy.customConfig -- Override HAProxy's default configs, if used **all** options need to be specified.
+  # This parameter supports using Helm templates to insert values dynamically
+  ## By default this chart will parse Vector's configuration from customConfig to generate HAProxy's config, this generated config
+  ## can be overwritten with haproxy.customConfig
+  customConfig: |
+    global
+      log stdout format raw local0
+      maxconn 4096
+      stats socket /tmp/haproxy
+      hard-stop-after {{ .Values.haproxy.terminationGracePeriodSeconds }}s
+
+    defaults
+      log     global
+      option  dontlognull
+      retries 3
+      option  redispatch
+      option  allbackups
+      timeout client 5s
+      timeout server 5s
+      timeout connect 5s
+
+    resolvers coredns
+      nameserver dns1 kube-dns.kube-system.svc.cluster.local:53
+      resolve_retries 3
+      timeout resolve 2s
+      timeout retry 1s
+      accepted_payload_size 8192
+      hold valid 10s
+      hold obsolete 60s
+
+    frontend stats
+      mode http
+      bind :::1024
+      option httplog
+      http-request use-service prometheus-exporter if { path /metrics }
+
+    frontend datadog-agent
+      mode http
+      bind :::8282
+      option httplog
+      default_backend datadog-agent
+
+    backend datadog-agent
+      mode http
+      balance roundrobin
+      option tcp-check
+      server-template srv 10 _datadog-agent._tcp.{{ include "vector.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.cluster.local resolvers coredns check

--- a/charts/vector/templates/NOTES.txt
+++ b/charts/vector/templates/NOTES.txt
@@ -1,37 +1,5 @@
-__   __  __
-\ \ / / / /
- \ V / / /
-  \_/  \/
-V E C T O R
+{{ include "_logo" . | indent 34 }}
 
-{{ if (eq .Values.role "Aggregator") }}
-  {{- if not .Values.customConfig }}
-Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
+{{ template "_divider" }}
 
-	kubectl -n {{ .Release.Namespace }} exec -it statefulset/{{ include "vector.fullname" . }} -- vector top 
-  {{- else if .Values.customConfig.api.enabled }}
-Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
-
-	kubectl -n {{ .Release.Namespace }} exec -it statefulset/{{ include "vector.fullname" . }} -- vector top --url {{ printf "http://%s/graphql" .Values.customConfig.api.address | default "http://127.0.0.1:8686/graphql" }}
-  {{- end }}
-{{ else if (eq .Values.role "Stateless-Aggregator") }}
-  {{- if not .Values.customConfig }}
-Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
-
-	kubectl -n {{ .Release.Namespace }} exec -it deployment/{{ include "vector.fullname" . }} -- vector top 
-  {{- else if .Values.customConfig.api.enabled }}
-Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
-
-	kubectl -n {{ .Release.Namespace }} exec -it deployment/{{ include "vector.fullname" . }} -- vector top --url {{ printf "http://%s/graphql" .Values.customConfig.api.address | default "http://127.0.0.1:8686/graphql" }}
-  {{- end }}
-{{ else if (eq .Values.role "Agent") }}
-  {{- if not .Values.customConfig }}
-Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
-
-	kubectl -n {{ .Release.Namespace }} exec -it daemonset/{{ include "vector.fullname" . }} -- vector top 
-  {{- else if .Values.customConfig.api.enabled }}
-Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
-
-	kubectl -n {{ .Release.Namespace }} exec -it daemonset/{{ include "vector.fullname" . }} -- vector top --url {{ printf "http://%s/graphql" .Values.customConfig.api.address | default "http://127.0.0.1:8686/graphql" }}
-  {{- end }}
-{{- end }}
+{{ include "_vector.top" . }}

--- a/charts/vector/templates/NOTES.txt
+++ b/charts/vector/templates/NOTES.txt
@@ -3,3 +3,6 @@
 {{ template "_divider" }}
 
 {{ include "_vector.top" . }}
+
+{{ if not .Values.quiet }}{{ include "_configure.datadog" . }}{{ end }}
+

--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -241,9 +241,95 @@ Print the `url` option for the Vector command.
   {{- if $.Values.customConfig -}}
     {{- if $.Values.customConfig.api -}}
       {{- if $.Values.customConfig.api.address -}}
---url {{ printf "http://%s/graphql" $.Values.customConfig.api.address }}
+{{ print "\\" }}
+        --url {{ printf "http://%s/graphql" $.Values.customConfig.api.address }}
       {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
 
+{{/*
+Configuring Datadog Agents to forward to Vector.
+This is really alpha level, and should be refactored
+to be more generally usable for other components.
+*/}}
+{{- define "_configure.datadog" -}}
+{{- $hasSourceDatadogAgent := false }}
+{{- $sourceDatadogAgentPort := "" }}
+{{- $hasTls := "" }}
+{{- $protocol := "http" }}
+{{- range $componentKind, $configs := .Values.customConfig }}
+  {{- if eq $componentKind "sources" }}
+    {{- range $componentId, $componentConfig := $configs }}
+      {{- if eq (get $componentConfig "type") "datadog_agent" }}
+	{{- $hasSourceDatadogAgent = true }}
+        {{- $sourceDatadogAgentPort = mustRegexFind "[0-9]+$" (get $componentConfig "address") }}
+	{{- if (hasKey $componentConfig "tls") }}
+	  {{- $tlsOpts := get $componentConfig "tls" }}
+	  {{- $hasTls = get $tlsOpts "enabled" }}
+	  {{- if $hasTls }}{{ $protocol = "https" }}{{ end }}
+	{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if or (not .Values.customConfig) (and .Values.customConfig $hasSourceDatadogAgent) }}
+{{- template "_divider" }}
+
+{{ print "\033[36;1mdatadog_agent:\033[0m" }}
+
+To forward logs from Datadog Agents deployed with the {{ include "_fmt.yellow" "datadog" }} Helm chart,
+include the following in the {{ include "_fmt.yellow" "values.yaml" }} for your {{ include "_fmt.yellow" "datadog" }} chart:
+
+For Datadog Agents version {{ include "_fmt.yellow" "7.34" }}/{{ include "_fmt.yellow" "6.34" }} or lower:
+
+{{ include "_fmt.blue" "datadog:" }}
+  {{ include "_fmt.blue" "containerExclude:" }} "name:vector"
+  {{ include "_fmt.blue" "logs:" }}
+    {{ include "_fmt.blue" "enabled:" }} {{ include "_fmt.yellow" "true" }}
+    {{ include "_fmt.blue" "containerCollectAll:" }} {{ include "_fmt.yellow" "true" }}
+{{ include "_fmt.blue" "agents:" }}
+  {{ include "_fmt.blue" "useConfigMap:" }} {{ include "_fmt.yellow" "true" }}
+  {{ include "_fmt.blue" "customAgentConfig:" }}
+    {{ include "_fmt.blue" "kubelet_tls_verify:" }} {{ include "_fmt.yellow" "false" }}
+    {{ include "_fmt.blue" "logs_config:" }}
+      {{- if .Values.haproxy.enabled }}
+      {{ include "_fmt.blue" "logs_dd_url:" }} "{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+      {{- else }}
+      {{ include "_fmt.blue" "logs_dd_url:" }} "{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+      {{- end }}
+      {{- if $hasTls }}
+      {{ include "_fmt.blue" "logs_no_ssl:" }} {{ include "_fmt.yellow" "false" }}
+      {{- else }}
+      {{ include "_fmt.blue" "logs_no_ssl:" }} {{ include "_fmt.yellow" "true" }}
+      {{- end }}
+      {{ include "_fmt.blue" "use_http:" }} {{ include "_fmt.yellow" "true" }}
+{{- end }}
+
+For Datadog Agents version {{ include "_fmt.yellow" "7.35" }}/{{ include "_fmt.yellow" "6.35" }} or greater:
+
+{{ include "_fmt.blue" "datadog:" }}
+  {{ include "_fmt.blue" "containerExclude:" }} "name:vector"
+  {{ include "_fmt.blue" "logs:" }}
+    {{ include "_fmt.blue" "enabled:" }} {{ include "_fmt.yellow" "true" }}
+    {{ include "_fmt.blue" "containerCollectAll:" }} {{ include "_fmt.yellow" "true" }}
+{{ include "_fmt.blue" "agents:" }}
+  {{ include "_fmt.blue" "useConfigMap:" }} {{ include "_fmt.yellow" "true" }}
+  {{ include "_fmt.blue" "customAgentConfig:" }}
+    {{ include "_fmt.blue" "kubelet_tls_verify:" }} {{ include "_fmt.yellow" "false" }}
+    {{ include "_fmt.blue" "vector:" }}
+      {{ include "_fmt.blue" "logs:" }}
+        {{ include "_fmt.blue" "enabled:" }} {{ include "_fmt.yellow" "true" }}
+        {{- if .Values.haproxy.enabled }}
+        {{ include "_fmt.blue" "url:" }} "{{ $protocol }}://{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+        {{- else }}
+        {{ include "_fmt.blue" "url:" }} "{{ $protocol }}://{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+        {{- end }}
+      {{ include "_fmt.blue" "metrics:" }}
+        {{ include "_fmt.blue" "enabled:" }} {{ include "_fmt.yellow" "true" }}
+        {{- if .Values.haproxy.enabled }}
+        {{ include "_fmt.blue" "url:" }} "{{ $protocol }}://{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+        {{- else }}
+        {{ include "_fmt.blue" "url:" }} "{{ $protocol }}://{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+        {{- end }}
+{{- end }}


### PR DESCRIPTION
- feat(vector): Improve help text printed by NOTES.txt and reduce duplication of internal templates (#189)
- chore(deps): bump helm/chart-releaser-action from 1.3.0 to 1.4.0 (#190)
- docs(vector): Add quickstart values and docs (#176)
- feat(vector): Add help output for configurations with datadog_agent source (#178)
- fix(vector): Bump Vector to v0.20.1 (#195)
