### PR TITLE
feat(vector): add RBAC to list and watch nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [vector-0.11.0] - 2022-05-20
+
+### Vector
+
+#### Features
+
+- Add ability to list and watch nodes ([081fa33](https://github.com/vectordotdev/helm-charts/commit/081fa33118f63cfde6e6cae0c0e1a430e53948eb))
+
 ## [vector-0.10.3] - 2022-05-06
 
 ### Vector

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.10.3"
+version: "0.11.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.10.3](https://img.shields.io/badge/Version-0.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.21.2-distroless-libc](https://img.shields.io/badge/AppVersion-0.21.2--distroless--libc-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.21.2-distroless-libc](https://img.shields.io/badge/AppVersion-0.21.2--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/templates/rbac.yaml
+++ b/charts/vector/templates/rbac.yaml
@@ -12,6 +12,7 @@ rules:
       - ""
     resources:
       - namespaces
+      - nodes
       - pods
     verbs:
       - list


### PR DESCRIPTION
The ability to list and watch nodes will be required to annotate logs from `kubernetes_logs` sources in the future. 

See https://github.com/vectordotdev/vector/pull/12730 for more details.