### PR TITLE
feat(vector): Add digest option to vector image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [vector-0.13.0] - 2022-06-13
+
+### Vector
+
+#### Features
+
+- Add digest option to vector image ([6e54a0a](https://github.com/vectordotdev/helm-charts/commit/6e54a0a463c47ec57e5f8b315e40a07ae584b878))
+
 ## [vector-0.12.0] - 2022-06-01
 
 ### Vector

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.12.1"
+version: "0.13.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.22.0--distroless--libc-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.22.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 
@@ -146,6 +146,7 @@ helm install --name <RELEASE_NAME> \
 | image.pullPolicy | string | `"IfNotPresent"` | Vector image pullPolicy |
 | image.pullSecrets | list | `[]` | Agent repository pullSecret (ex: specify docker registry credentials) # Ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
 | image.repository | string | `"timberio/vector"` | Override default registry + name for Vector |
+| image.sha | string | `""` | Vector image sha to use |
 | image.tag | string | Chart's appVersion | Vector image tag to use |
 | ingress.annotations | object | `{}` | Set annotations on the Ingress |
 | ingress.className | string | `""` | Specify the ingressClassName, requires Kubernetes >= 1.18 # Ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress |

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -31,7 +31,11 @@ containers:
     securityContext:
 {{ toYaml . | indent 6 }}
 {{- end }}
+{{- if .Values.image.sha }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
+{{- else }}
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+{{- end }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- with .Values.command }}
     command:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -34,6 +34,8 @@ image:
   # image.tag -- Vector image tag to use
   # @default -- Chart's appVersion
   tag: ""
+  # image.sha -- Vector image sha to use
+  sha: ""
 
 # replicas -- Set the number of Pods to create
 ## Valid for Aggregator and Stateless-Aggregator


### PR DESCRIPTION
Signed-off-by: Tomer Epstein <tomer.epstein@sap.com>

**Motivation**
add better integrity to the image version, we should provide a way to add a digest option to the chart images this way we can validate the image version

**Approach**
How does this change address the problem?

Add digest option to vector chart,
By adding a new sha field to the pod file and concatenate it to the image string address when provided.

**Pull Request status**
- [x]  Initial implementation
- [ ]  Refactoring
- [ ]  Unit tests
- [ ] Integration tests