### PR TITLE
feat(vector): Add option to use KEDA autoscaler

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -154,6 +154,14 @@ helm install --name <RELEASE_NAME> \
 | ingress.hosts | list | `[]` | Configure the hosts and paths for the Ingress |
 | ingress.tls | list | `[]` | Configure TLS for the Ingress |
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pod |
+| keda.behavior | object | `{}` | Used to modify HPA's scaling behavior # Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior |
+| keda.cooldownPeriod | int | `300` | Interval to wait after the last trigger reported active before scaling back to 0 for Vector's KEDA |
+| keda.enabled | bool | `false` | Enabled KEDA for the Aggregator and Stateless-Aggregator |
+| keda.maxReplicas | int | `20` | Maximum replicas for Vector's KEDA |
+| keda.minReplicas | int | `2` | Minimum replicas for Vector's KEDA |
+| keda.pollingInterval | int | `30` | Interval to check each trigger for Vector's KEDA |
+| keda.scaledObject | object | `{"annotations":{}}` | Anotations to add to KEDA ScaledObject resource # Ref: https://keda.sh/docs/2.7/concepts/scaling-deployments/#scaledobject-spec |
+| keda.triggers | list | `[]` | List of triggers to activate scaling of the target resource. # Ref: https://keda.sh/docs/2.7/concepts/scaling-deployments/#triggers |
 | livenessProbe | object | `{}` | Override default liveness probe settings, if customConfig is used requires customConfig.api.enabled true # Requires Vector's API to be enabled |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allow Vector to be scheduled on selected nodes # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector # Ref: https://kubernetes.io/docs/user-guide/node-selection/ |

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "vector.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if and (not .Values.autoscaling.enabled) (not .Values.keda.enabled) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   selector:

--- a/charts/vector/templates/hpa.yaml
+++ b/charts/vector/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if or (eq .Values.role "Aggregator") (eq .Values.role "Stateless-Aggregator") -}}
-{{- if and .Values.autoscaling.enabled (.Capabilities.APIVersions.Has "autoscaling/v2beta2") }}
+{{- if and .Values.autoscaling.enabled (.Capabilities.APIVersions.Has "autoscaling/v2beta2") (not .Values.keda.enabled)}}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/vector/templates/keda.yaml
+++ b/charts/vector/templates/keda.yaml
@@ -1,0 +1,34 @@
+{{- if or (eq .Values.role "Aggregator") (eq .Values.role "Stateless-Aggregator") -}}
+{{- if and .Values.keda.enabled (not .Values.autoscaling.enabled)}}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "vector.fullname" . }}
+  labels:
+    {{- include "vector.labels" . | nindent 4 }}
+  {{- if .Values.keda.scaledObject.annotations }}
+  annotations: {{ toYaml .Values.keda.scaledObject.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "vector.fullname" . }}
+  pollingInterval: {{ .Values.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.keda.maxReplicas }}
+  triggers:
+{{- with .Values.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+{{- if .Values.keda.behavior }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "vector.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if and (not .Values.autoscaling.enabled) (not .Values.keda.enabled) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 ## Agent - DaemonSet
 ## Aggregator - StatefulSet
 ## Stateless-Aggregator - Deployment
-role: "Agent"
+role: "Aggregator"
 
 # rollWorkload -- Add a checksum of the generated ConfigMap to workload annotations
 rollWorkload: true

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 ## Agent - DaemonSet
 ## Aggregator - StatefulSet
 ## Stateless-Aggregator - Deployment
-role: "Aggregator"
+role: "Agent"
 
 # rollWorkload -- Add a checksum of the generated ConfigMap to workload annotations
 rollWorkload: true
@@ -58,6 +58,7 @@ secrets:
 
 ## Configure a HorizontalPodAutoscaler for Vector
 ## Valid for Aggregator and Stateless-Aggregator roles
+## You can't enable both HorizontalPodAutoscaler and Kubernetes Event-driven Autoscaling
 autoscaling:
   # autoscaling.enabled -- Enabled autoscaling for the Aggregator and Stateless-Aggregator
   enabled: false
@@ -78,6 +79,44 @@ autoscaling:
     #      target:
     #        type: AverageValue
     #        averageValue: 95
+
+## Configure a Kubernetes Event-driven Autoscaling for Vector
+## Ref: https://keda.sh/
+## Valid for Aggregator and Stateless-Aggregator roles
+## You can't enable both Kubernetes Event-driven Autoscaling and HorizontalPodAutoscaler
+keda:
+  # keda.enabled -- Enabled KEDA for the Aggregator and Stateless-Aggregator
+  enabled: false
+  # keda.minReplicas -- Minimum replicas for Vector's KEDA
+  minReplicas: 2
+  # keda.maxReplicas -- Maximum replicas for Vector's KEDA
+  maxReplicas: 20
+  # keda.pollingInterval -- Interval to check each trigger for Vector's KEDA
+  pollingInterval: 30
+  # keda.cooldownPeriod -- Interval to wait after the last trigger reported active before scaling back to 0 for Vector's KEDA
+  cooldownPeriod: 300
+  # keda.scaledObject -- Anotations to add to KEDA ScaledObject resource
+  ## Ref: https://keda.sh/docs/2.7/concepts/scaling-deployments/#scaledobject-spec
+  scaledObject:
+    annotations: {}
+  # keda.behavior -- Used to modify HPA's scaling behavior
+  ## Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+  behavior: {}
+  #  scaleDown:
+  #    stabilizationWindowSeconds: 300
+  #    policies:
+  #    - type: Percent
+  #      value: 100
+  #      periodSeconds: 15
+  # keda.triggers -- List of triggers to activate scaling of the target resource.
+  ## Ref: https://keda.sh/docs/2.7/concepts/scaling-deployments/#triggers
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://<prometheus-host>:9090
+        metricName: vector_utilization_scaler
+        threshold: '0.85'
+        query: avg(vector_utilization{component_type="remap"}[5m])
 
 podDisruptionBudget:
   # podDisruptionBudget.enabled -- Enable a PodDisruptionBudget for Vector


### PR DESCRIPTION
Motivation
[KEDA](https://keda.sh/) provides possibility to scale pods based on any metric (or query) available in prometheus or [many overs](https://keda.sh/docs/2.7/scalers/) datasources. Since vector have wide variety of internal metrics better suitable for scaling decisions, it's nice to have possibility to choose KEDA instead of plain HPA

Approach
How does this change address the problem?

It adds necessary values to helm chart and KEDA ScaledObject template