### PR TITLE
Fix HAProxy Configmap Conditional

### DIFF
--- a/charts/vector/templates/haproxy/configmap.yaml
+++ b/charts/vector/templates/haproxy/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "haproxy.labels" . | nindent 4 }}
 data:
   haproxy.cfg: |
-  {{- if .Values.customConfig }}
+  {{- if .Values.haproxy.customConfig }}
   {{ tpl .Values.haproxy.customConfig . | nindent 4 }}
   {{- else }}
     global


### PR DESCRIPTION
# Purpose

The `ConfigMap` template is checking for the `customConfig` property for Vector as opposed to the HAProxy `customConfig`. If using `customConfig` for Vector, the rendered HAProxy config is empty and Kubernetes probes fail.