### PR TITLE
feat(vector): Add lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [vector-0.15.0] - 2022-07-19
+
+### Vector
+
+#### Features
+
+- Add lifecycle ([2dc5602](https://github.com/vectordotdev/helm-charts/commit/2dc560265d9008157ce7389f1147a21f9d1fbeef))
+
 ## [vector-0.14.0] - 2022-07-11
 
 ### Vector

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.14.0"
+version: "0.15.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.23.0--distroless--libc-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.23.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 
@@ -154,6 +154,7 @@ helm install --name <RELEASE_NAME> \
 | ingress.hosts | list | `[]` | Configure the hosts and paths for the Ingress |
 | ingress.tls | list | `[]` | Configure TLS for the Ingress |
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pod |
+| lifecycle | object | `{}` | Set vector lifecycle hooks |
 | livenessProbe | object | `{}` | Override default liveness probe settings, if customConfig is used requires customConfig.api.enabled true # Requires Vector's API to be enabled |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allow Vector to be scheduled on selected nodes # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector # Ref: https://kubernetes.io/docs/user-guide/node-selection/ |

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -114,6 +114,10 @@ containers:
     resources:
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- with .Values.lifecycle }}
+    lifecycle:
+{{- toYaml . | nindent 6 }}
+{{- end }}
     volumeMounts:
       - name: data
         {{- if .Values.existingConfigMaps }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -157,6 +157,14 @@ resources: {}
   #   cpu: 200m
   #   memory: 256Mi
 
+# lifecycle -- Set vector lifecycle hooks
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command:
+  #     - /bin/sleep
+  #     - "10"
+
 # updateStrategy -- Customize the updateStrategy used to replace Vector Pods
 ## Also used for the DeploymentStrategy for Stateless-Aggregators
 ## Valid options are used depending on the chosen role


### PR DESCRIPTION
Hi, there are missing optional lifecycle hooks, so this PR reintroduce them, as they are in deprecated vector-agent chart.