### PR TITLE
fix: extraVolumeMounts

### DIFF
--- a/charts/vector/ci/extraContainers-and-extraVolumeMounts-values.yaml
+++ b/charts/vector/ci/extraContainers-and-extraVolumeMounts-values.yaml
@@ -1,0 +1,19 @@
+# Including extraContainers and extraVolumes
+## Values file for testing adding extraContainers and extraVolumeMounts to Vector Pods.
+extraContainers:
+  - name: sleep
+    image: busybox
+    command: ['sh', '-c', "sleep 5"]
+extraVolumes:
+  - name: podinfo
+    downwardAPI:
+      items:
+        - path: "labels"
+          fieldRef:
+            fieldPath: metadata.labels
+        - path: "annotations"
+          fieldRef:
+            fieldPath: metadata.annotations
+extraVolumeMounts:
+  - name: podinfo
+    mountPath: "/etc/podinfo"

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -145,11 +145,11 @@ containers:
         mountPath: "/host/sys"
         readOnly: true
 {{- end }}
-{{- with .Values.extraContainers }}
-{{ toYaml . | indent 2 }}
-{{- end }}
 {{- with .Values.extraVolumeMounts }}
 {{- toYaml . | nindent 6 }}
+{{- end }}
+{{- with .Values.extraContainers }}
+{{ toYaml . | indent 2 }}
 {{- end }}
 terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- with .Values.nodeSelector }}


### PR DESCRIPTION
`extraVolumeMounts` should be located before `extraContainers`
otherwise, if extraContainers is not null, yaml is not valid and extraVolumeMounts is impossible to use.