### PR TITLE
fix(ci): Skip release if it already exists

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,3 +28,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_SKIP_EXISTING: true


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

We're not longer publishing `vector-agent` or `vector-aggregator`, and ignoring them during linting as well. This should stop the release process from trying to publish them as well.

```shell
Looking up latest tag...
Discovering changed charts since 'vector-0.16.0'...
Installing chart-releaser on /opt/hostedtoolcache/cr/v1.4.1/x86_64...
Adding cr directory to PATH...
Packaging chart 'charts/vector-agent'...
Successfully packaged chart in /home/runner/work/helm-charts/helm-charts/charts/vector-agent and saved it to: .cr-release-packages/vector-agent-0.21.3.tgz
Packaging chart 'charts/vector-aggregator'...
Successfully packaged chart in /home/runner/work/helm-charts/helm-charts/charts/vector-aggregator and saved it to: .cr-release-packages/vector-aggregator-0.21.3.tgz
Packaging chart 'charts/vector'...
Successfully packaged chart in /home/runner/work/helm-charts/helm-charts/charts/vector and saved it to: .cr-release-packages/vector-0.16.1.tgz
Releasing charts...
Error: error creating GitHub release vector-agent-0.21.3: POST https://api.github.com/repos/vectordotdev/helm-charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
Usage:
  cr upload [flags]

Flags:
  -c, --commit string                  Target commit for release
  -b, --git-base-url string            GitHub Base URL (only needed for private GitHub) (default "https://api.github.com/")
  -r, --git-repo string                GitHub repository
  -u, --git-upload-url string          GitHub Upload URL (only needed for private GitHub) (default "https://uploads.github.com/")
  -h, --help                           help for upload
  -o, --owner string                   GitHub username or organization
  -p, --package-path string            Path to directory with chart packages (default ".cr-release-packages")
      --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
      --release-notes-file string      Markdown file with chart release notes. If it is set to empty string, or the file is not found, the chart description will be used instead
      --skip-existing                  Skip upload if release exists
  -t, --token string                   GitHub Auth Token

Global Flags:
      --config string   Config file (default is $HOME/.cr.yaml)
```
