### PR TITLE
fix(vector): Remove color codes in NOTES.txt

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.16.3"
+version: "0.16.4"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.16.3](https://img.shields.io/badge/Version-0.16.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.24.1--distroless--libc-informational?style=flat-square)
+![Version: 0.16.4](https://img.shields.io/badge/Version-0.16.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.24.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/templates/NOTES.txt
+++ b/charts/vector/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{ template "_divider" }}
+
 {{ include "_logo" . | indent 34 }}
 
 {{ template "_divider" }}

--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -178,12 +178,10 @@ Generate a single ContainerPort based on a component configuration.
 Print Vector's logo.
 */}}
 {{- define "_logo" -}}
-{{ print "\033[36m" }}
 {{ print "__   __  __" }}
 {{ print "\\ \\ / / / /" }}
 {{ print " \\ V / / /  " }}
 {{ print "  \\_/  \\/  " }}
-{{ print "\033[0m" }}
 {{ print "V E C T O R" }}
 {{- end }}
 
@@ -195,20 +193,6 @@ Print line divider.
 {{- end }}
 
 {{/*
-Print the supplied value in yellow.
-*/}}
-{{- define "_fmt.yellow" -}}
-{{ print "\033[0;33m" . "\033[0m" }}
-{{- end }}
-
-{{/*
-Print the supplied value in blue.
-*/}}
-{{- define "_fmt.blue" -}}
-{{ print "\033[36m" . "\033[0m" }}
-{{- end }}
-
-{{/*
 Print `vector top` instructions.
 */}}
 {{- define "_vector.top" -}}
@@ -217,12 +201,12 @@ Print `vector top` instructions.
 {{ println "API to view internal metrics by running:" }}
   {{- $resource := include "_vector.role" $ -}}
   {{- $url := include "_vector.url" $ }}
-  {{ include "_fmt.yellow" "$" }} kubectl -n {{ $.Release.Namespace }} exec -it {{ $resource }}/{{ include "vector.fullname" $ }} -- vector top {{ $url }}
+  $ kubectl -n {{ $.Release.Namespace }} exec -it {{ $resource }}/{{ include "vector.fullname" $ }} -- vector top {{ $url }}
   {{- else -}}
   {{- $resource := include "_vector.role" $ -}}
 {{ print "Vector is starting in your cluster. After a few minutes, you can view Vector's" }}
 {{ println "internal logs by running:" }}
-  {{ include "_fmt.yellow" "$" }} kubectl -n {{ $.Release.Namespace }} logs -f {{ $resource }}/{{ include "vector.fullname" $ }}
+  $ kubectl -n {{ $.Release.Namespace }} logs -f {{ $resource }}/{{ include "vector.fullname" $ }}
   {{- end }}
 {{- end }}
 
@@ -298,60 +282,60 @@ to be more generally usable for other components.
 {{- if or (not .Values.customConfig) (and .Values.customConfig $hasSourceDatadogAgent) }}
 {{- template "_divider" }}
 
-{{ print "\033[36;1mdatadog_agent:\033[0m" }}
+{{ print "datadog_agent:" }}
 
-To forward logs from Datadog Agents deployed with the {{ include "_fmt.yellow" "datadog" }} Helm chart,
-include the following in the {{ include "_fmt.yellow" "values.yaml" }} for your {{ include "_fmt.yellow" "datadog" }} chart:
+To forward logs from Datadog Agents deployed with the "datadog" Helm chart,
+include the following in the "values.yaml" for your "datadog" chart:
 
-For Datadog Agents version {{ include "_fmt.yellow" "7.34" }}/{{ include "_fmt.yellow" "6.34" }} or lower:
+For Datadog Agents version "7.34"/"6.34" or lower:
 
-{{ include "_fmt.blue" "datadog:" }}
-  {{ include "_fmt.blue" "containerExclude:" }} "name:vector"
-  {{ include "_fmt.blue" "logs:" }}
-    {{ include "_fmt.blue" "enabled:" }} {{ include "_fmt.yellow" "true" }}
-    {{ include "_fmt.blue" "containerCollectAll:" }} {{ include "_fmt.yellow" "true" }}
-{{ include "_fmt.blue" "agents:" }}
-  {{ include "_fmt.blue" "useConfigMap:" }} {{ include "_fmt.yellow" "true" }}
-  {{ include "_fmt.blue" "customAgentConfig:" }}
-    {{ include "_fmt.blue" "kubelet_tls_verify:" }} {{ include "_fmt.yellow" "false" }}
-    {{ include "_fmt.blue" "logs_config:" }}
+datadog:
+  containerExclude: "name:vector"
+  logs:
+    enabled: true
+    containerCollectAll: true
+agents:
+  useConfigMap: true
+  customAgentConfig:
+    kubelet_tls_verify: false
+    logs_config:
       {{- if .Values.haproxy.enabled }}
-      {{ include "_fmt.blue" "logs_dd_url:" }} "{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+      logs_dd_url: "{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
       {{- else }}
-      {{ include "_fmt.blue" "logs_dd_url:" }} "{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+      logs_dd_url: "{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
       {{- end }}
       {{- if $hasTls }}
-      {{ include "_fmt.blue" "logs_no_ssl:" }} {{ include "_fmt.yellow" "false" }}
+      logs_no_ssl: false
       {{- else }}
-      {{ include "_fmt.blue" "logs_no_ssl:" }} {{ include "_fmt.yellow" "true" }}
+      logs_no_ssl: true
       {{- end }}
-      {{ include "_fmt.blue" "use_http:" }} {{ include "_fmt.yellow" "true" }}
+      use_http: true
 {{- end }}
 
-For Datadog Agents version {{ include "_fmt.yellow" "7.35" }}/{{ include "_fmt.yellow" "6.35" }} or greater:
+For Datadog Agents version "7.35"/"6.35" or greater:
 
-{{ include "_fmt.blue" "datadog:" }}
-  {{ include "_fmt.blue" "containerExclude:" }} "name:vector"
-  {{ include "_fmt.blue" "logs:" }}
-    {{ include "_fmt.blue" "enabled:" }} {{ include "_fmt.yellow" "true" }}
-    {{ include "_fmt.blue" "containerCollectAll:" }} {{ include "_fmt.yellow" "true" }}
-{{ include "_fmt.blue" "agents:" }}
-  {{ include "_fmt.blue" "useConfigMap:" }} {{ include "_fmt.yellow" "true" }}
-  {{ include "_fmt.blue" "customAgentConfig:" }}
-    {{ include "_fmt.blue" "kubelet_tls_verify:" }} {{ include "_fmt.yellow" "false" }}
-    {{ include "_fmt.blue" "vector:" }}
-      {{ include "_fmt.blue" "logs:" }}
-        {{ include "_fmt.blue" "enabled:" }} {{ include "_fmt.yellow" "true" }}
+datadog:
+  containerExclude: "name:vector"
+  logs:
+    enabled: true
+    containerCollectAll: true
+agents:
+  useConfigMap: true
+  customAgentConfig:
+    kubelet_tls_verify: false
+    vector:
+      logs:
+        enabled: true
         {{- if .Values.haproxy.enabled }}
-        {{ include "_fmt.blue" "url:" }} "{{ $protocol }}://{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+        url: "{{ $protocol }}://{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
         {{- else }}
-        {{ include "_fmt.blue" "url:" }} "{{ $protocol }}://{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+        url: "{{ $protocol }}://{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
         {{- end }}
-      {{ include "_fmt.blue" "metrics:" }}
-        {{ include "_fmt.blue" "enabled:" }} {{ include "_fmt.yellow" "true" }}
+      metrics:
+        enabled: true
         {{- if .Values.haproxy.enabled }}
-        {{ include "_fmt.blue" "url:" }} "{{ $protocol }}://{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+        url: "{{ $protocol }}://{{ include "haproxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
         {{- else }}
-        {{ include "_fmt.blue" "url:" }} "{{ $protocol }}://{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
+        url: "{{ $protocol }}://{{ include "vector.fullname" $ }}.{{ $.Release.Namespace }}:{{ $sourceDatadogAgentPort | default "8282" }}"
         {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Fixes #254 by removing the escape codes completely, as there isn't a native way to detect support during templating. It was fun while it lasted, but ultimately not great for Windows users.

Below is the NOTES output from an example install.

```text
NOTES:
--------------------------------------------------------------------------------

                                  __   __  __
                                  \ \ / / / /
                                   \ V / / /
                                    \_/  \/
                                  V E C T O R

--------------------------------------------------------------------------------

Vector is starting in your cluster. After a few minutes, you can use Vector's
API to view internal metrics by running:

  $ kubectl -n default exec -it statefulset/vector -- vector top

--------------------------------------------------------------------------------

datadog_agent:

To forward logs from Datadog Agents deployed with the "datadog" Helm chart,
include the following in the "values.yaml" for your "datadog" chart:

For Datadog Agents version "7.34"/"6.34" or lower:

datadog:
  containerExclude: "name:vector"
  logs:
    enabled: true
    containerCollectAll: true
agents:
  useConfigMap: true
  customAgentConfig:
    kubelet_tls_verify: false
    logs_config:
      logs_dd_url: "vector.default:8282"
      logs_no_ssl: true
      use_http: true

For Datadog Agents version "7.35"/"6.35" or greater:

datadog:
  containerExclude: "name:vector"
  logs:
    enabled: true
    containerCollectAll: true
agents:
  useConfigMap: true
  customAgentConfig:
    kubelet_tls_verify: false
    vector:
      logs:
        enabled: true
        url: "http://vector.default:8282"
      metrics:
        enabled: true
        url: "http://vector.default:8282"
```
