### PR TITLE
fix(vector): Update haproxy to use image.pullSecrets

### DIFF
--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.haproxy.imagePullSecrets }}
+      {{- with .Values.haproxy.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Very simple fix, the template for haproxy deployment seems to use the old naming for imagePullSecrets

Thanks in advance! :smile_cat: 