### PR TITLE
fix HorizontalPodAutoscaler helm template api version

### DIFF
--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -82,7 +82,7 @@ Return the appropriate apiVersion for PodDisruptionBudget policy APIs.
 Return the appropriate apiVersion for HPA autoscaling APIs.
 */}}
 {{- define "autoscaling.apiVersion" -}}
-{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23" .Capabilities.KubeVersion.Version) -}}
+{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") (semverCompare ">=1.23" .Capabilities.KubeVersion.Version) -}}
 "autoscaling/v2"
 {{- else -}}
 "autoscaling/v2beta2"

--- a/charts/vector/templates/haproxy/_helpers.tpl
+++ b/charts/vector/templates/haproxy/_helpers.tpl
@@ -43,7 +43,7 @@ Create the name of the service account to use
 Return the appropriate apiVersion for HPA autoscaling APIs.
 */}}
 {{- define "autoscaling.apiVersion" -}}
-{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2") (semverCompare ">=1.23" .Capabilities.KubeVersion.Version) -}}
+{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") (semverCompare ">=1.23" .Capabilities.KubeVersion.Version) -}}
 "autoscaling/v2"
 {{- else -}}
 "autoscaling/v2beta2"


### PR DESCRIPTION
# Description
ArgoCD uses `helm template` which fails to get the right api-version on k8s-version 1.21
On 1.21 cluster - the helm chart will fail!

# Solution
As described [here](https://github.com/argoproj/argo-cd/issues/7291), the solution is to use `.Capabilities.APIVersions.Has` over `api/version/kind` instead of over just `api/version`

# Validation
Enable autoscaling on values.yml and run
```bash
helm template . --kube-version 1.21
```
Before fix the hpa would get `v2` (which does not exist on 1.21), after fix it will get `v2beta2` 

Run
```bash
helm template . --kube-version 1.24
```
Before and after fix you'll get `v2`