### PR TITLE
feat(vector): add annotations for deployment, daemonset, statefulset

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.19.0"
+version: "0.19.1"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -213,6 +213,7 @@ helm install --name <RELEASE_NAME> \
 | tolerations | list | `[]` | Configure Vector Pods to be scheduled on [tainted](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) nodes. |
 | topologySpreadConstraints | list | `[]` | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for Vector Pods. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
 | updateStrategy | object | `{}` | Customize the updateStrategy used to replace Vector Pods, this is also used for the DeploymentStrategy for the "Stateless-Aggregators". Valid options depend on the chosen role. |
+| workloadResouceAnnotations | object | `{}` | Set annotations on the Vector Daemonset, Deployment or Statefulset. |
 
 ### HAProxy values
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.27.0--distroless--libc-informational?style=flat-square)
+![Version: 0.19.1](https://img.shields.io/badge/Version-0.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.27.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 
@@ -213,7 +213,7 @@ helm install --name <RELEASE_NAME> \
 | tolerations | list | `[]` | Configure Vector Pods to be scheduled on [tainted](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) nodes. |
 | topologySpreadConstraints | list | `[]` | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for Vector Pods. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
 | updateStrategy | object | `{}` | Customize the updateStrategy used to replace Vector Pods, this is also used for the DeploymentStrategy for the "Stateless-Aggregators". Valid options depend on the chosen role. |
-| workloadResouceAnnotations | object | `{}` | Set annotations on the Vector Daemonset, Deployment or Statefulset. |
+| workloadResourceAnnotations | object | `{}` | Set annotations on the Vector DaemonSet, Deployment or StatefulSet. |
 
 ### HAProxy values
 

--- a/charts/vector/ci/aggregator-all-values.yaml
+++ b/charts/vector/ci/aggregator-all-values.yaml
@@ -11,6 +11,10 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
+workloadResourceAnnotations:
+  kubernetes.io/description: "Vector aggregator deployment."
+  configmap.reloader.stakater.com/reload: additional-configmap
+
 resources:
   requests:
     cpu: 200m

--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "vector.fullname" . }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
+  annotations:
+    {{- include ".Values.workloadResourceAnnotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "vector.labels" . | nindent 4 }}
   annotations:
-    {{- include ".Values.workloadResourceAnnotations" . | nindent 4 }}
+    {{- toYaml .Values.workloadResourceAnnotations | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "vector.fullname" . }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
+  annotations:
+    {{- include ".Values.workloadResourceAnnotations" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "vector.labels" . | nindent 4 }}
   annotations:
-    {{- include ".Values.workloadResourceAnnotations" . | nindent 4 }}
+    {{- toYaml .Values.workloadResourceAnnotations | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "vector.fullname" . }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
+  annotations:
+    {{- include ".Values.workloadResourceAnnotations" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "vector.labels" . | nindent 4 }}
   annotations:
-    {{- include ".Values.workloadResourceAnnotations" . | nindent 4 }}
+    {{- toYaml .Values.workloadResourceAnnotations | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -131,6 +131,9 @@ podHostNetwork: false
 # for Vector Pods.
 podSecurityContext: {}
 
+# workloadResouceAnnotations -- Set annotations on the Vector Daemonset, Deployment or Statefulset.
+workloadResouceAnnotations: {}
+
 # securityContext -- Specify securityContext on Vector containers.
 securityContext: {}
 

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -131,7 +131,7 @@ podHostNetwork: false
 # for Vector Pods.
 podSecurityContext: {}
 
-# workloadResouceAnnotations -- Set annotations on the Vector Daemonset, Deployment or Statefulset.
+# workloadResouceAnnotations -- Set annotations on the Vector DaemonSet, Deployment or StatefulSet.
 workloadResouceAnnotations: {}
 
 # securityContext -- Specify securityContext on Vector containers.

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -131,8 +131,8 @@ podHostNetwork: false
 # for Vector Pods.
 podSecurityContext: {}
 
-# workloadResouceAnnotations -- Set annotations on the Vector DaemonSet, Deployment or StatefulSet.
-workloadResouceAnnotations: {}
+# workloadResourceAnnotations -- Set annotations on the Vector DaemonSet, Deployment or StatefulSet.
+workloadResourceAnnotations: {}
 
 # securityContext -- Specify securityContext on Vector containers.
 securityContext: {}


### PR DESCRIPTION
Would it be alright to add annotations for the pod controller of Vector? 

My specific use-case is that ArgoCD deployment doesn't work with the rollWorkload option, so I would like to be able to put the stakater/reloader annotation on the deployment to roll Vector when its ConfigMap dependencies are updated.