### PR TITLE
feat(vector): add minReadySeconds for daemonsets

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.20.2"
+version: "0.22.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -159,6 +159,7 @@ helm install --name <RELEASE_NAME> \
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
 | livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
+| minReadySeconds| int | `0` | Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
 | nodeSelector | object | `{}` | Configure a [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for Vector Pods. |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.20.2](https://img.shields.io/badge/Version-0.20.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.28.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.28.1--distroless--libc-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.28.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.28.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 
@@ -159,7 +159,7 @@ helm install --name <RELEASE_NAME> \
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
 | livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
-| minReadySeconds| int | `0` | Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to pass healthchecks before it is considered available. |
+| minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
 | nodeSelector | object | `{}` | Configure a [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for Vector Pods. |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.28.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.28.1--distroless--libc-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.29.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -12,6 +12,7 @@ spec:
     matchLabels:
       {{- include "vector.selectorLabels" . | nindent 6 }}
   {{- with .Values.updateStrategy }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -183,6 +183,11 @@ lifecycle: {}
   #     - /bin/sleep
   #     - "10"
 
+
+# Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to pass healthchecks before it is 
+# considered available: 
+minReadySeconds: 0
+
 # updateStrategy -- Customize the updateStrategy used to replace Vector Pods, this is also used for the
 # DeploymentStrategy for the "Stateless-Aggregators". Valid options depend on the chosen role.
 

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -184,8 +184,8 @@ lifecycle: {}
   #     - "10"
 
 
-# Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to pass healthchecks before it is 
-# considered available: 
+# minReadySeconds -- Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to
+# pass healthchecks before it is considered available.
 minReadySeconds: 0
 
 # updateStrategy -- Customize the updateStrategy used to replace Vector Pods, this is also used for the


### PR DESCRIPTION
add [minReadySeconds](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec:~:text=minReadySeconds%20(int32)). useful when we have a lot of nodes and we wanted to be sure the pod is fully deployed, otherwise may want to reschedule this job and investigate.