### PR TITLE
Fix default/missing storageClassName

### DIFF
--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -50,7 +50,9 @@ spec:
       name: data
     spec:
       accessModes: {{ .Values.persistence.accessModes }}
+      {{- if .Values.persistence.storageClassName }}
       storageClassName: {{ .Values.persistence.storageClassName }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.persistence.size }}


### PR DESCRIPTION
Do not include storageClassName attribute if not provided (default). Currently the persistence.storageClassName value is not provided by default, which results in an empty string storageClassName attribute in the StatefulSet template. This inadvertently disables dynamic PV provisioning.

If no persistence.storageClassName value is provided, then the attribute should not be present in the rendered StatefulSet, allowing the PVC to use the cluster's default storage class.