### PR TITLE
Remap `host` to the node name for Agent `host_metrics`

### DIFF
--- a/charts/vector/templates/configmap.yaml
+++ b/charts/vector/templates/configmap.yaml
@@ -74,10 +74,15 @@ data:
         type: host_metrics
       internal_metrics:
         type: internal_metrics
+    transforms:
+      host_metrics_with_node_name:
+        type: remap
+        inputs: [host_metrics]
+        source: .tags.host = get_env_var!("VECTOR_SELF_NODE_NAME")
     sinks:
       prom_exporter:
         type: prometheus_exporter
-        inputs: [host_metrics, internal_metrics]
+        inputs: [host_metrics_with_node_name, internal_metrics]
         address: 0.0.0.0:9090
       stdout:
         type: console


### PR DESCRIPTION
The current behavior of the chart provides pod names of the agent to Prometheus, which isn't very helpful for host metrics.  This change is a much better default behavior, at least in my novice opinion.