### PR TITLE
daemonset error on updateStrategy with minReadySeconds

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.22.0"
+version: "0.22.1"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.30.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.30.0--distroless--libc-informational?style=flat-square)
+![Version: 0.22.1](https://img.shields.io/badge/Version-0.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.30.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.30.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -11,8 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "vector.selectorLabels" . | nindent 6 }}
-  {{- with .Values.updateStrategy }}
   minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
PR to update minReadySeconds

### Description:
There's a bug here, [daemonset.yaml](https://github.com/vectordotdev/helm-charts/blob/develop/charts/vector/templates/daemonset.yaml). The `minReadySeconds: {{ .Values.minReadySeconds }}` error out with `nil` exception.

It's causing an error like the below with the following values;

```yaml
# values.yaml
updateStrategy:
  rollingUpdate:
    maxSurge: 0
    maxUnavailable: 10%
```

```
Error: template: vector/templates/daemonset.yaml:15:29: executing "vector/templates/daemonset.yaml" at <.Values.minReadySeconds>: nil pointer evaluating interface {}.minReadySeconds

Use --debug flag to render out invalid YAML
```