### PR TITLE
feat(vector): volumes/volumeMounts, logLevel and dataDir

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.22.1"
+version: "0.23.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -137,6 +137,8 @@ helm install --name <RELEASE_NAME> \
 | containerPorts | list | `[]` | Manually define Vector's containerPorts, overriding automated generation of containerPorts. |
 | customConfig | object | `{}` | Override Vector's default configs, if used **all** options need to be specified. This section supports using helm templates to populate dynamic values. See Vector's [configuration documentation](https://vector.dev/docs/reference/configuration/) for all options. |
 | dataDir | string | `""` | Specify the path for Vector's data, only used when existingConfigMaps are used. |
+| defaultVolumes | list | See `values.yaml`	| Default volumes that are mounted into pods. In most cases, these should not be changed. Use extraVolumes/extraVolumeMounts for additional custom volumes. |
+| defaultVolumeMounts | list | See `values.yaml`	| Default volume mounts. Corresponds to volumes. |
 | dnsConfig | object | `{}` | Specify the [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) options for Vector Pods. |
 | dnsPolicy | string | `"ClusterFirst"` | Specify the [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for Vector Pods. |
 | env | list | `[]` | Set environment variables for Vector containers. |
@@ -159,6 +161,7 @@ helm install --name <RELEASE_NAME> \
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
 | livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
+| logLevel | string | `"info"` | Override Vector's default log level. |
 | minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
 | nodeSelector | object | `{}` | Configure a [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for Vector Pods. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.22.1](https://img.shields.io/badge/Version-0.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.30.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.30.0--distroless--libc-informational?style=flat-square)
+![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.30.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.30.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 
@@ -137,8 +137,8 @@ helm install --name <RELEASE_NAME> \
 | containerPorts | list | `[]` | Manually define Vector's containerPorts, overriding automated generation of containerPorts. |
 | customConfig | object | `{}` | Override Vector's default configs, if used **all** options need to be specified. This section supports using helm templates to populate dynamic values. See Vector's [configuration documentation](https://vector.dev/docs/reference/configuration/) for all options. |
 | dataDir | string | `""` | Specify the path for Vector's data, only used when existingConfigMaps are used. |
-| defaultVolumes | list | See `values.yaml`	| Default volumes that are mounted into pods. In most cases, these should not be changed. Use extraVolumes/extraVolumeMounts for additional custom volumes. |
-| defaultVolumeMounts | list | See `values.yaml`	| Default volume mounts. Corresponds to volumes. |
+| defaultVolumeMounts | list | See `values.yaml` | Default volume mounts. Corresponds to `volumes`. |
+| defaultVolumes | list | See `values.yaml` | Default volumes that are mounted into pods. In most cases, these should not be changed. Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes. |
 | dnsConfig | object | `{}` | Specify the [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) options for Vector Pods. |
 | dnsPolicy | string | `"ClusterFirst"` | Specify the [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for Vector Pods. |
 | env | list | `[]` | Set environment variables for Vector containers. |
@@ -161,7 +161,7 @@ helm install --name <RELEASE_NAME> \
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
 | livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
-| logLevel | string | `"info"` | Override Vector's default log level. |
+| logLevel | string | `"info"` |  |
 | minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
 | nodeSelector | object | `{}` | Configure a [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for Vector Pods. |
@@ -169,6 +169,7 @@ helm install --name <RELEASE_NAME> \
 | persistence.enabled | bool | `false` | If true, create and use PersistentVolumeClaims. |
 | persistence.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim to use. Valid for the "Aggregator" role. |
 | persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Specifies the finalizers of PersistentVolumeClaims. Valid for the "Aggregator" role. |
+| persistence.hostPath.enabled | bool | `true` | If true, use hostPath persistence. Valid for the "Agent" role, if it's disabled the "Agent" role will use emptyDir. |
 | persistence.hostPath.path | string | `"/var/lib/vector"` | Override path used for hostPath persistence. Valid for the "Agent" role, persistence is always used for the "Agent" role. |
 | persistence.selectors | object | `{}` | Specifies the selectors for PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.size | string | `"10Gi"` | Specifies the size of PersistentVolumeClaims. Valid for the "Aggregator" role. |

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -71,6 +71,8 @@ containers:
         value: "/host/proc"
       - name: SYSFS_ROOT
         value: "/host/sys"
+      - name: VECTOR_LOG
+        value: "{{ .Values.logLevel | default "info" }}"
 {{- end }}
 {{- if .Values.envFrom }}
 {{- with .Values.envFrom }}
@@ -140,18 +142,9 @@ containers:
         mountPath: "/etc/vector/"
         readOnly: true
 {{- if (eq .Values.role "Agent") }}
-      - name: var-log
-        mountPath: "/var/log/"
-        readOnly: true
-      - name: var-lib
-        mountPath: "/var/lib"
-        readOnly: true
-      - name: procfs
-        mountPath: "/host/proc"
-        readOnly: true
-      - name: sysfs
-        mountPath: "/host/sys"
-        readOnly: true
+{{- with .Values.defaultVolumeMounts }}
+{{- toYaml . | nindent 6 }}
+{{- end }}
 {{- end }}
 {{- with .Values.extraVolumeMounts }}
 {{- toYaml . | nindent 6 }}
@@ -201,20 +194,15 @@ volumes:
 {{- end }}
 {{- if (eq .Values.role "Agent") }}
   - name: data
+  {{- if .Values.persistence.hostPath.enabled }}
     hostPath:
       path: {{ .Values.persistence.hostPath.path | quote }}
-  - name: var-log
-    hostPath:
-      path: "/var/log/"
-  - name: var-lib
-    hostPath:
-      path: "/var/lib/"
-  - name: procfs
-    hostPath:
-      path: "/proc"
-  - name: sysfs
-    hostPath:
-      path: "/sys"
+  {{- else }}
+    emptyDir: {}
+  {{- end }}
+    {{- with .Values.defaultVolumes }}
+    {{- toYaml . | nindent 2 }}
+    {{- end }}
 {{- end }}
 {{- with .Values.extraVolumes }}
 {{- toYaml . | nindent 2 }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -306,8 +306,9 @@ customConfig: {}
   #     encoding:
   #       codec: json
 
-# -- Default volumes that are mounted into pods. In most cases, these should not be changed.
+# defaultVolumes -- Default volumes that are mounted into pods. In most cases, these should not be changed.
 # Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes.
+# @default -- See `values.yaml`
 defaultVolumes:
   - name: var-log
     hostPath:
@@ -322,7 +323,8 @@ defaultVolumes:
     hostPath:
       path: "/sys"
 
-# -- Default volume mounts. Corresponds to `volumes`.
+# defaultVolumeMounts -- Default volume mounts. Corresponds to `volumes`.
+# @default -- See `values.yaml`
 defaultVolumeMounts:
   - name: var-log
     mountPath: "/var/log/"

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -306,7 +306,8 @@ customConfig: {}
   #     encoding:
   #       codec: json
 
-# Default volumes. They can be manipulated.
+# -- Default volumes that are mounted into pods. In most cases, these should not be changed.
+# Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes.
 defaultVolumes:
   - name: var-log
     hostPath:
@@ -321,7 +322,7 @@ defaultVolumes:
     hostPath:
       path: "/sys"
 
-# Default volume mounts. They can be manipulated.
+# -- Default volume mounts. Corresponds to `volumes`.
 defaultVolumeMounts:
   - name: var-log
     mountPath: "/var/log/"
@@ -435,7 +436,7 @@ podMonitor:
   # podMonitor.honorTimestamps -- If true, honor_timestamps is set to true in the [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
   honorTimestamps: true
 
-# Log level for Vector. Default is "info".
+# Log level for Vector.
 logLevel: "info"
 
 # Optional built-in HAProxy load balancer.

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -371,7 +371,7 @@ persistence:
 
   hostPath:
     # persistence.hostPath.enabled -- If true, use hostPath persistence. Valid for the "Agent" role, if it's disabled
-    # the "Agent" role will use emptyDir for persistence.
+    # the "Agent" role will use emptyDir.
     enabled: true
     # persistence.hostPath.path -- Override path used for hostPath persistence. Valid for the "Agent" role, persistence
     # is always used for the "Agent" role.

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -306,6 +306,36 @@ customConfig: {}
   #     encoding:
   #       codec: json
 
+# Default volumes. They can be manipulated.
+defaultVolumes:
+  - name: var-log
+    hostPath:
+      path: "/var/log/"
+  - name: var-lib
+    hostPath:
+      path: "/var/lib/"
+  - name: procfs
+    hostPath:
+      path: "/proc"
+  - name: sysfs
+    hostPath:
+      path: "/sys"
+
+# Default volume mounts. They can be manipulated.
+defaultVolumeMounts:
+  - name: var-log
+    mountPath: "/var/log/"
+    readOnly: true
+  - name: var-lib
+    mountPath: "/var/lib"
+    readOnly: true
+  - name: procfs
+    mountPath: "/host/proc"
+    readOnly: true
+  - name: sysfs
+    mountPath: "/host/sys"
+    readOnly: true
+
 # extraVolumes -- Additional Volumes to use with Vector Pods.
 extraVolumes: []
 
@@ -340,6 +370,9 @@ persistence:
   selectors: {}
 
   hostPath:
+    # persistence.hostPath.enabled -- If true, use hostPath persistence. Valid for the "Agent" role, if it's disabled
+    # the "Agent" role will use emptyDir for persistence.
+    enabled: true
     # persistence.hostPath.path -- Override path used for hostPath persistence. Valid for the "Agent" role, persistence
     # is always used for the "Agent" role.
     path: "/var/lib/vector"
@@ -401,6 +434,9 @@ podMonitor:
   honorLabels: false
   # podMonitor.honorTimestamps -- If true, honor_timestamps is set to true in the [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
   honorTimestamps: true
+
+# Log level for Vector. Default is "info".
+logLevel: "info"
 
 # Optional built-in HAProxy load balancer.
 haproxy:


### PR DESCRIPTION
Signed-off-by: Ugur Can Ozturk [ugurozturk918@gmail.com](mailto:ugurozturk918@gmail.com)

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
* Using hostPath as a data directory might not be best practice unless it has to be; I believe users who would like to use emptyDir instead of hostPath should be able to do that.

* It would be great if mounted volumeMounts can be overridden by users based on the logs data path that they want to collect.

* Another good feature would be changing log level easily

#### Which issue(s) this PR fixes:
As an alternative log collector we're trying to use vector hoping it is more lightweight and performative. But since it's trying to write mounted hostpath for the data-dir; and since as a cluster-wide policy we don't allow any write actions for the hostpath volumes; it could not run with current helm chart values. I'm hoping this PR essentially can solve this problem.

Ref:
[Kubernetes Documentation for the hostPath volumes](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)