### PR TITLE
feat(vector): add podMonitor.podTargetLabels

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.24.1"
+version: "0.25.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -187,6 +187,7 @@ helm install --name <RELEASE_NAME> \
 | podMonitor.interval | string | `nil` | Override the interval at which metrics should be scraped. |
 | podMonitor.jobLabel | string | `"app.kubernetes.io/name"` | Override the label to retrieve the job name from. |
 | podMonitor.metricRelabelings | list | `[]` | [MetricRelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion. |
+| podMonitor.podTargetLabels | list | `[]` | [podTargetLabels](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitorSpec) transfers labels on the Kubernetes Pod onto the target. |
 | podMonitor.path | string | `"/metrics"` | Override the path to scrape. |
 | podMonitor.port | string | `"prom-exporter"` | Override the port to scrape. |
 | podMonitor.relabelings | list | `[]` | [RelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before scraping. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -187,8 +187,8 @@ helm install --name <RELEASE_NAME> \
 | podMonitor.interval | string | `nil` | Override the interval at which metrics should be scraped. |
 | podMonitor.jobLabel | string | `"app.kubernetes.io/name"` | Override the label to retrieve the job name from. |
 | podMonitor.metricRelabelings | list | `[]` | [MetricRelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion. |
-| podMonitor.podTargetLabels | list | `[]` | [podTargetLabels](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitorSpec) transfers labels on the Kubernetes Pod onto the target. |
 | podMonitor.path | string | `"/metrics"` | Override the path to scrape. |
+| podMonitor.podTargetLabels | list | `[]` | [podTargetLabels](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitorSpec) transfers labels on the Kubernetes Pod onto the target. |
 | podMonitor.port | string | `"prom-exporter"` | Override the port to scrape. |
 | podMonitor.relabelings | list | `[]` | [RelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before scraping. |
 | podMonitor.scrapeTimeout | string | `nil` | Override the timeout after which the scrape is ended. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.24.1](https://img.shields.io/badge/Version-0.24.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.32.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.32.1--distroless--libc-informational?style=flat-square)
+![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.32.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.32.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/templates/podmonitor.yaml
+++ b/charts/vector/templates/podmonitor.yaml
@@ -16,6 +16,10 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
+  {{- with .Values.podMonitor.podTargetLabels }}
+  podTargetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   podMetricsEndpoints:
     - port: {{ .Values.podMonitor.port }}
       path: {{ .Values.podMonitor.path }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -431,6 +431,9 @@ podMonitor:
   # podMonitor.metricRelabelings -- [MetricRelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs)
   # to apply to samples before ingestion.
   metricRelabelings: []
+  # podMonitor.podTargetLabels -- [podTargetLabels](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitorSpec)
+  # transfers labels on the Kubernetes Pod onto the target.
+  podTargetLabels: []
   # podMonitor.additionalLabels -- Adds additional labels to the PodMonitor.
   additionalLabels: {}
   # podMonitor.honorLabels -- If true, honor_labels is set to true in the [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).


### PR DESCRIPTION
Motivation:

- add the ability to pass specified labels from the vector's pod to metrics

Solution: 

Add podTargetLabels to PodMonitor Spec.

More info:
https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitorSpec