### PR TITLE
feat: support shareProcessNamespace is pod.spec

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -218,6 +218,7 @@ helm install --name <RELEASE_NAME> \
 | serviceAccount.create | bool | `true` | If true, create a ServiceAccount for Vector. |
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and serviceAccount.create is true, a name is generated using the fullname template. |
 | serviceHeadless.enabled | bool | `true` | If true, create and provide a Headless Service resource for Vector. |
+| shareProcessNamespace | bool | `false` | Specify the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) options for Vector Pods. |
 | terminationGracePeriodSeconds | int | `60` | Override Vector's terminationGracePeriodSeconds. |
 | tolerations | list | `[]` | Configure Vector Pods to be scheduled on [tainted](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) nodes. |
 | topologySpreadConstraints | list | `[]` | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for Vector Pods. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -223,6 +223,7 @@ helm install --name <RELEASE_NAME> \
 | topologySpreadConstraints | list | `[]` | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for Vector Pods. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
 | updateStrategy | object | `{}` | Customize the updateStrategy used to replace Vector Pods, this is also used for the DeploymentStrategy for the "Stateless-Aggregators". Valid options depend on the chosen role. |
 | workloadResourceAnnotations | object | `{}` | Set annotations on the Vector DaemonSet, Deployment or StatefulSet. |
+| extraObjects | list | `[]` | Create extra manifests via values. Would be passed through `tpl` for templating. |
 
 ### HAProxy values
 

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -16,6 +16,9 @@ priorityClassName: {{ . }}
 {{- with .Values.dnsPolicy }}
 dnsPolicy: {{ . }}
 {{- end }}
+{{- with .Values.shareProcessNamespace }}
+shareProcessNamespace: {{ . }}
+{{- end }}
 {{- with .Values.dnsConfig }}
 dnsConfig:
 {{ toYaml . | indent 2 }}

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -13,11 +13,11 @@ securityContext:
 {{- with .Values.podPriorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
-{{- with .Values.dnsPolicy }}
-dnsPolicy: {{ . }}
-{{- end }}
 {{- with .Values.shareProcessNamespace }}
 shareProcessNamespace: {{ . }}
+{{- end }}
+{{- with .Values.dnsPolicy }}
+dnsPolicy: {{ . }}
 {{- end }}
 {{- with .Values.dnsConfig }}
 dnsConfig:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -399,6 +399,10 @@ dnsConfig: {}
   #     value: "2"
   #   - name: edns0
 
+# shareProcessNamespace -- Specify the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/)
+# options for Vector Pods.
+shareProcessNamespace: false
+
 # livenessProbe -- Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled
 # to be set to true.
 livenessProbe: {}


### PR DESCRIPTION
This adds the ability to set the `pod.spec.shareProcessNamespace` value in the pod template (defaults to `false`), which allows the sidecars container to be able to send the reload signal (`SIGHUP`) to the vector process. 