### PR TITLE
Add annotations to Vector's HPA

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -125,6 +125,7 @@ helm install --name <RELEASE_NAME> \
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Configure [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) rules for Vector Pods. |
 | args | list | `["--config-dir","/etc/vector/"]` | Override Vector's default arguments. |
+| autoscaling.annotations | object | `{}` | Annotations to add to Vector's HPA. |
 | autoscaling.behavior | object | `{}` | Configure separate scale-up and scale-down behaviors. |
 | autoscaling.customMetric | object | `{}` | Target a custom metric for autoscaling. |
 | autoscaling.enabled | bool | `false` | Create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) for Vector. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |

--- a/charts/vector/templates/hpa.yaml
+++ b/charts/vector/templates/hpa.yaml
@@ -6,6 +6,8 @@ metadata:
   name: {{ include "vector.fullname" . }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.autoscaling.annotations | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -61,6 +61,8 @@ autoscaling:
   # autoscaling.enabled -- Create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
   # for Vector. Valid for the "Aggregator" and "Stateless-Aggregator" roles.
   enabled: false
+  # autoscaling.annotations -- Annotations to add to Vector's HPA.
+  annotations: {}
   # autoscaling.minReplicas -- Minimum replicas for Vector's HPA.
   minReplicas: 1
   # autoscaling.maxReplicas -- Maximum replicas for Vector's HPA.


### PR DESCRIPTION
Allowing to add annotations to the Vector's HPA, this is needed when someone want to use [kube-metrics-adapter](https://github.com/zalando-incubator/kube-metrics-adapter/blob/e54f3b88cf5e60e02c8523b4b806dfd5dfe00f28/README.md)