### PR TITLE
Remove defaults for PDB

### DIFF
--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -88,9 +88,9 @@ podDisruptionBudget:
   # for Vector.
   enabled: false
   # podDisruptionBudget.minAvailable -- The number of Pods that must still be available after an eviction.
-  minAvailable: 1
+  # minAvailable: 1
   # podDisruptionBudget.maxUnavailable -- (int) The number of Pods that can be unavailable after an eviction.
-  maxUnavailable:
+  # maxUnavailable:
 
 rbac:
   # rbac.create -- If true, create and use RBAC resources. Only valid for the "Agent" role.


### PR DESCRIPTION
- Remove default for PDB. This allows the user to to set only the values required. 
- Currently they add both both `minAvailable` and `maxUnavailable` are added even of I just want to set `maxUnavailable`.
- lot of k8s deployments only allow one of this 2 values to be passed causing the deployment to fail