### PR TITLE
fix: rendering custom config tpl

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.39.0--distroless--libc-informational?style=flat-square)
+![Version: 0.34.1](https://img.shields.io/badge/Version-0.34.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.39.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -176,10 +176,6 @@ Generate an array of ContainerPorts based on `.Values.customConfig`.
       {{- end }}
     {{- end }}
   {{- end }}
-{{- else if or .Values.livenessProbe .Values.readinessProbe }}
-- name: api
-  containerPort: 8686
-  protocol: TCP
 {{- end }}
 {{- end }}
 

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -138,8 +138,10 @@ containers:
       - name: data
         {{- if .Values.existingConfigMaps }}
         mountPath: "{{ if .Values.dataDir }}{{ .Values.dataDir }}{{ else }}{{ fail "Specify `dataDir` if you're using `existingConfigMaps`" }}{{ end }}"
-        {{- else }}
+        {{- else if not (typeIs "string" .Values.customConfig) }}
         mountPath: "{{ .Values.customConfig.data_dir | default "/vector-data-dir" }}"
+        {{- else }}
+        mountPath: "/vector-data-dir"
         {{- end }}
       - name: config
         mountPath: "/etc/vector/"

--- a/charts/vector/templates/configmap.yaml
+++ b/charts/vector/templates/configmap.yaml
@@ -9,7 +9,11 @@ metadata:
 data:
   {{- if .Values.customConfig }}
   vector.yaml: |
-{{ tpl (toYaml .Values.customConfig) . | indent 4 }}
+    {{- if typeIs "string" .Values.customConfig -}}
+    {{ tpl .Values.customConfig . | nindent 4 }}
+    {{- else -}}
+    {{ tpl (toYaml .Values.customConfig) . | nindent 4 }}
+    {{- end }}
   {{- else if or (eq .Values.role "Aggregator") (eq .Values.role "Stateless-Aggregator") }}
   aggregator.yaml: |
     data_dir: /vector-data-dir


### PR DESCRIPTION
There's `{{ tpl (toYaml .Values.customConfig) . | indent 4 }}`, but we can't actually use tpl becuase there's several points accessing and iterating child objects of `.Values.customConfig`.
So I made them not to access or iterate child objects if customConfig is string.