### PR TITLE
enhancement(vector): Add `persistence.retentionPolicy` for configuring Statefulset PVC retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [vector-0.30.0] - 2023-12-04
+
+### Vector
+
+#### Features
+
+- Add `persistence.retentionPolicy` for configuring Statefulset PVC retention policy (#343) ([f94671a](f94671a699bae83b687f68d889b8e278273488f1))
+
 ## [vector-0.29.0] - 2023-11-16
 
 ### Vector

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.29.1"
+version: "0.30.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.29.0"
+version: "0.30.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -173,7 +173,7 @@ helm install --name <RELEASE_NAME> \
 | persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Specifies the finalizers of PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.hostPath.enabled | bool | `true` | If true, use hostPath persistence. Valid for the "Agent" role, if it's disabled the "Agent" role will use emptyDir. |
 | persistence.hostPath.path | string | `"/var/lib/vector"` | Override path used for hostPath persistence. Valid for the "Agent" role, persistence is always used for the "Agent" role. |
-| persistence.retentionPolicy | object | `{}` | Configure a [PersistentVolumeClaimRetentionPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) for Vector. Valid for the "Aggregator" role. |
+| persistence.retentionPolicy | object | `{}` | Configure a [PersistentVolumeClaimRetentionPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) for Vector's PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.selectors | object | `{}` | Specifies the selectors for PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.size | string | `"10Gi"` | Specifies the size of PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | podAnnotations | object | `{}` | Set annotations on Vector Pods. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.36.2](https://img.shields.io/badge/Version-0.36.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.41.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.41.1--distroless--libc-informational?style=flat-square)
+![Version: 0.37.0](https://img.shields.io/badge/Version-0.37.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.41.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.41.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -170,6 +170,7 @@ helm install --name <RELEASE_NAME> \
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.enabled | bool | `false` | If true, create and use PersistentVolumeClaims. |
 | persistence.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim to use. Valid for the "Aggregator" role. |
+| persistence.retentionPolicy | object | `{}` | Configure a [PersistentVolumeClaimRetentionPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) for Vector. Valid for the "Aggregator" role. |
 | persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Specifies the finalizers of PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.hostPath.enabled | bool | `true` | If true, use hostPath persistence. Valid for the "Agent" role, if it's disabled the "Agent" role will use emptyDir. |
 | persistence.hostPath.path | string | `"/var/lib/vector"` | Override path used for hostPath persistence. Valid for the "Agent" role, persistence is always used for the "Agent" role. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -170,10 +170,10 @@ helm install --name <RELEASE_NAME> \
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.enabled | bool | `false` | If true, create and use PersistentVolumeClaims. |
 | persistence.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim to use. Valid for the "Aggregator" role. |
-| persistence.retentionPolicy | object | `{}` | Configure a [PersistentVolumeClaimRetentionPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) for Vector. Valid for the "Aggregator" role. |
 | persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Specifies the finalizers of PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.hostPath.enabled | bool | `true` | If true, use hostPath persistence. Valid for the "Agent" role, if it's disabled the "Agent" role will use emptyDir. |
 | persistence.hostPath.path | string | `"/var/lib/vector"` | Override path used for hostPath persistence. Valid for the "Agent" role, persistence is always used for the "Agent" role. |
+| persistence.retentionPolicy | object | `{}` | Configure a [PersistentVolumeClaimRetentionPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) for Vector. Valid for the "Aggregator" role. |
 | persistence.selectors | object | `{}` | Specifies the selectors for PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | persistence.size | string | `"10Gi"` | Specifies the size of PersistentVolumeClaims. Valid for the "Aggregator" role. |
 | podAnnotations | object | `{}` | Set annotations on Vector Pods. |

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -13,7 +13,7 @@ spec:
   {{- end }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.persistence.retentionPolicy) }}
-  persistentVolumeClaimRetentionPolicy: 
+  persistentVolumeClaimRetentionPolicy:
     {{ toYaml .Values.persistence.retentionPolicy | nindent 4 }}
   {{- end }}
   selector:

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -12,6 +12,9 @@ spec:
   replicas: {{ .Values.replicas }}
   {{- end }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
+  {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.persistence.retentionPolicy) }}
+  persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.persistence.retentionPolicy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "vector.selectorLabels" . | nindent 6 }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -13,7 +13,8 @@ spec:
   {{- end }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.persistence.retentionPolicy) }}
-  persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.persistence.retentionPolicy | nindent 4 }}
+  persistentVolumeClaimRetentionPolicy: 
+    {{ toYaml .Values.persistence.retentionPolicy | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -365,20 +365,11 @@ persistence:
   # "Aggregator" role.
   # storageClassName: default
 
-  # The [Persistent Volume Claim (PVC) retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
-  # controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
-  # WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted,
-  # and WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down.
-  #
-  # Example:
-  #
-  # ```yaml
-  # retentionPolicy:
-  #   whenDeleted: Retain
-  #   whenScaled: Retain
-  # ```
-  # @type: map
+  # persistence.retentionPolicy -- Configure a [PersistentVolumeClaimRetentionPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
+  # for Vector's PersistentVolumeClaims. Valid for the "Aggregator" role.
   retentionPolicy: {}
+  #  whenDeleted: Retain
+  #  whenScaled: Retain
 
   # persistence.accessModes -- Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role.
   accessModes:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -367,9 +367,9 @@ persistence:
 
   # The [Persistent Volume Claim (PVC) retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
   # controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
-  # WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted, 
+  # WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted,
   # and WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down.
-  # 
+  #
   # Example:
   #
   # ```yaml

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -365,6 +365,21 @@ persistence:
   # "Aggregator" role.
   # storageClassName: default
 
+  # The [Persistent Volume Claim (PVC) retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
+  # controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+  # WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted, 
+  # and WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down.
+  # 
+  # Example:
+  #
+  # ```yaml
+  # retentionPolicy:
+  #   whenDeleted: Retain
+  #   whenScaled: Retain
+  # ```
+  # @type: map
+  retentionPolicy: {}
+
   # persistence.accessModes -- Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role.
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Hello! 👋 

This PR adds a new variable in the `values.yaml` file: `persistence.retentionPolicy`. 

This allow users to define which is the PVC retention policy for the created Statefulsets. Kubernetes by default sets a `Remain` policy, meaning that no PVC are removed when the Statefulset is down-scaled or removed.  With this new setting, users can tell Kubernetes to remove these disks, for example for non production environment. 

This variable has a default set to `{}`, meaning that this setting will not be applied and Kubernetes will apply its default value, so current statefulsets will not be affected.

More info about this new feature here:
https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention

## Some tests

I've run the following commands to ensure that the output is expected:

**Using this setting on a K8S cluster below 1.23**: Setting do not appear on the rendered statefulset.

```shell
$ helm template \                        
      -s templates/statefulset.yaml  \
      --kube-version "1.22" --set 'persistence.retentionPolicy.whenDeleted=Delete' \
      . |                  
      yq -r '.spec.persistentVolumeClaimRetentionPolicy'
null
```

**Using this setting on a k8s cluster above 1.23**: Setting appears on the rendered statefulset.

```shell
$ helm template \
      -s templates/statefulset.yaml  \
      --kube-version "1.27" --set 'persistence.retentionPolicy.whenDeleted=Delete' \
      . |
      yq -r '.spec.persistentVolumeClaimRetentionPolicy'
{
  "whenDeleted": "Delete"
}

$ helm template \
      -s templates/statefulset.yaml  \
      --kube-version "1.27" \
      --set 'persistence.retentionPolicy.whenScaled=Delete' \
      . |
      yq -r '.spec.persistentVolumeClaimRetentionPolicy'
{
  "whenScaled": "Delete"
}
```

**Using the default value in a k8s cluster above 1.23**: Setting do not appear on the rendered statefulset.

```shell
$ helm template \
      -s templates/statefulset.yaml  \
      --kube-version "1.27" \                                                                            
      . |
      yq -r '.spec.persistentVolumeClaimRetentionPolicy'
null
```
