### PR TITLE
fix(vector): add minReadySeconds to StatefulSet and Deployment specs

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -164,7 +164,7 @@ helm install --name <RELEASE_NAME> \
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
 | livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
 | logLevel | string | `"info"` |  |
-| minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up pod should wait to pass healthchecks before it is considered available. |
+| minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
 | nodeSelector | object | `{}` | Configure a [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for Vector Pods. |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role. |

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       {{- include "vector.selectorLabels" . | nindent 6 }}
-  minReadySeconds: {{ .Values.minReadySeconds }}
   {{- with .Values.updateStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -15,9 +15,6 @@ spec:
   selector:
     matchLabels:
       {{- include "vector.selectorLabels" . | nindent 6 }}
-  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
-  minReadySeconds: {{ .Values.minReadySeconds }}
-  {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -186,7 +186,7 @@ lifecycle: {}
   #     - "10"
 
 
-# minReadySeconds -- Specify the minimum number of seconds a newly spun up pod should wait to
+# minReadySeconds -- Specify the minimum number of seconds a newly spun up DaemonSet pod should wait to
 # pass healthchecks before it is considered available.
 minReadySeconds: 0
 


### PR DESCRIPTION
Reverts vectordotdev/helm-charts#367

Appears to have merged even though CI checks failed.