### PR TITLE
chore(vector): Specify the kube version when templating in CI

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -21,5 +21,5 @@ tar -xf /tmp/kubeval.tar.gz kubeval
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
   echo "Running kubeval for folder: '$CHART_DIR'"
-  helm dep up "${CHART_DIR}" && helm template --values "${CHART_DIR}"/ci/kubeval.yaml "${CHART_DIR}" | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
+  helm dep up "${CHART_DIR}" && helm template --kube-version "${KUBERNETES_VERSION#v}" --values "${CHART_DIR}"/ci/kubeval.yaml "${CHART_DIR}" | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
 done


### PR DESCRIPTION
This allows the template to render the correct manifest for the
kubernetes version under test.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
