### PR TITLE
chore(vector): Run CI on any changes

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -6,13 +6,7 @@ KUBEVAL_VERSION="0.16.1"
 SCHEMA_LOCATION="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/" # Up-to-date fork of instrumenta/kubernetes-json-schema
 OS=$(uname)
 
-CHANGED_CHARTS=${CHANGED_CHARTS:-${1:-}}
-if [ -n "$CHANGED_CHARTS" ];
-then
-  CHART_DIRS=$CHANGED_CHARTS
-else
-  CHART_DIRS=$(ls -d charts/*)
-fi
+CHART_DIRS="charts/vector charts/vector-aggregator charts/vector-agent"
 
 # install kubeval
 curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/v"${KUBEVAL_VERSION}"/kubeval-${OS}-amd64.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,34 +5,8 @@ on:
   pull_request:
 
 jobs:
-  changed:
-    runs-on: ubuntu-latest
-    outputs:
-      charts: ${{ steps.list-changed.outputs.changed }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed)
-          if [[ -n "$changed" ]]; then
-            echo -n "Charts changed:"
-            echo "$changed"
-            echo "::set-output name=changed::$changed"
-          else
-            echo "PR without any chart changes - failing"
-            exit 1
-          fi
-
   lint-chart:
     runs-on: ubuntu-latest
-    needs:
-      - changed
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,8 +21,6 @@ jobs:
 
   lint-docs:
     runs-on: ubuntu-latest
-    needs:
-      - changed
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -65,8 +37,6 @@ jobs:
 
   kubeval-chart:
     runs-on: ubuntu-latest
-    needs:
-      - changed
     strategy:
       matrix:
         # When changing versions here, check that the version exists at: https://github.com/yannh/kubernetes-json-schema and https://hub.docker.com/r/kindest/node/tags
@@ -91,7 +61,6 @@ jobs:
       - name: Run kubeval
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
-          CHANGED_CHARTS: ${{needs.changed.outputs.charts}}
         run: .github/kubeval.sh
 
   install-chart:


### PR DESCRIPTION
Without this PRs that don't make changes to any charts don't pass CI.
I think the overhead of just testing all charts is fairly minimal.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
