### PR TITLE
enhancement(vector): Allow external autoscaler

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.32.2"
+version: "0.33.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.32.1](https://img.shields.io/badge/Version-0.32.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.37.1--distroless--libc-informational?style=flat-square)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.37.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 
@@ -129,7 +129,7 @@ helm install --name <RELEASE_NAME> \
 | autoscaling.behavior | object | `{}` | Configure separate scale-up and scale-down behaviors. |
 | autoscaling.customMetric | object | `{}` | Target a custom metric for autoscaling. |
 | autoscaling.enabled | bool | `false` | Create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) for Vector. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
-| autoscaling.external | bool | `false` | Indicates whether Vector is controlled by an external autoscaler. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
+| autoscaling.external | bool | `false` | Set to `true` if using an external autoscaler like [KEDA](https://keda.sh/). Valid for the "Aggregator and "Stateless-Aggregator" roles. |
 | autoscaling.maxReplicas | int | `10` | Maximum replicas for Vector's HPA. |
 | autoscaling.minReplicas | int | `1` | Minimum replicas for Vector's HPA. |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization for Vector's HPA. |
@@ -235,7 +235,7 @@ helm install --name <RELEASE_NAME> \
 | haproxy.affinity | object | `{}` | Configure [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) rules for HAProxy Pods. |
 | haproxy.autoscaling.customMetric | object | `{}` | Target a custom metric for autoscaling. |
 | haproxy.autoscaling.enabled | bool | `false` | Create a HorizontalPodAutoscaler for HAProxy. |
-| haproxy.autoscaling.external | bool | `false` | Indicates whether HAProxy is controlled by an external HorizontalPodAutoscaler. |
+| haproxy.autoscaling.external | bool | `false` | HAProxy is controlled by an external HorizontalPodAutoscaler. |
 | haproxy.autoscaling.maxReplicas | int | `10` | Maximum replicas for HAProxy's HPA. |
 | haproxy.autoscaling.minReplicas | int | `1` | Minimum replicas for HAProxy's HPA. |
 | haproxy.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization for HAProxy's HPA. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -129,6 +129,7 @@ helm install --name <RELEASE_NAME> \
 | autoscaling.behavior | object | `{}` | Configure separate scale-up and scale-down behaviors. |
 | autoscaling.customMetric | object | `{}` | Target a custom metric for autoscaling. |
 | autoscaling.enabled | bool | `false` | Create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) for Vector. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
+| autoscaling.external | bool | `false` | Indicates whether Vector is controlled by an external autoscaler. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
 | autoscaling.maxReplicas | int | `10` | Maximum replicas for Vector's HPA. |
 | autoscaling.minReplicas | int | `1` | Minimum replicas for Vector's HPA. |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization for Vector's HPA. |
@@ -234,6 +235,7 @@ helm install --name <RELEASE_NAME> \
 | haproxy.affinity | object | `{}` | Configure [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) rules for HAProxy Pods. |
 | haproxy.autoscaling.customMetric | object | `{}` | Target a custom metric for autoscaling. |
 | haproxy.autoscaling.enabled | bool | `false` | Create a HorizontalPodAutoscaler for HAProxy. |
+| haproxy.autoscaling.external | bool | `false` | Indicates whether HAProxy is controlled by an external HorizontalPodAutoscaler. |
 | haproxy.autoscaling.maxReplicas | int | `10` | Maximum replicas for HAProxy's HPA. |
 | haproxy.autoscaling.minReplicas | int | `1` | Minimum replicas for HAProxy's HPA. |
 | haproxy.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization for HAProxy's HPA. |

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- toYaml .Values.workloadResourceAnnotations | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not (or .Values.autoscaling.enabled .Values.autoscaling.external) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   selector:

--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.haproxy.autoscaling.enabled }}
+  {{- if not (or .Values.haproxy.autoscaling.enabled .Values.haproxy.autoscaling.external) }}
   replicas: {{ .Values.haproxy.replicas }}
   {{- end }}
   selector:

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- toYaml .Values.workloadResourceAnnotations | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not (or .Values.autoscaling.enabled .Values.autoscaling.external) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -61,6 +61,9 @@ autoscaling:
   # autoscaling.enabled -- Create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
   # for Vector. Valid for the "Aggregator" and "Stateless-Aggregator" roles.
   enabled: false
+  # autoscaling.external -- Set to `true` if using an external autoscaler like [KEDA](https://keda.sh/).
+  # Valid for the "Aggregator and "Stateless-Aggregator" roles.
+  external: false
   # autoscaling.annotations -- Annotations to add to Vector's HPA.
   annotations: {}
   # autoscaling.minReplicas -- Minimum replicas for Vector's HPA.
@@ -572,6 +575,8 @@ haproxy:
   autoscaling:
     # haproxy.autoscaling.enabled -- Create a HorizontalPodAutoscaler for HAProxy.
     enabled: false
+    # haproxy.autoscaling.external -- HAProxy is controlled by an external HorizontalPodAutoscaler.
+    external: false
     # haproxy.autoscaling.minReplicas -- Minimum replicas for HAProxy's HPA.
     minReplicas: 1
     # haproxy.autoscaling.maxReplicas -- Maximum replicas for HAProxy's HPA.


### PR DESCRIPTION
When using any autoscaler, replicas should not be set on any Deployment or StatefulSet. This helm chart has hooks for defining an HPA, but there are times when users may want to create their own, or use something external like [KEDA](https://keda.sh). In our case, we want to use KEDA for scaling based on kafka lag and other triggers. This largely works as expected, but I need to prevent the `replicas` field from being populated, or else things appear out-of-sync when the external autoscaler is doing its thing (we use ArgoCD and it will show the project as out-of-sync because of replicas).

The feature here is just to offer an additional field under `autoscaling` options: `external: true/false`.