### PR TITLE
enhancement(vector): Update the image fields to allow for a static base name

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.33.1"
+version: "0.34.0"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.33.0"
+version: "0.33.1"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.38.0--distroless--libc-informational?style=flat-square)
+![Version: 0.33.1](https://img.shields.io/badge/Version-0.33.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.38.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.33.1](https://img.shields.io/badge/Version-0.33.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.38.0--distroless--libc-informational?style=flat-square)
+![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.38.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -151,12 +151,12 @@ helm install --name <RELEASE_NAME> \
 | extraVolumeMounts | list | `[]` | Additional Volume to mount into Vector Containers. |
 | extraVolumes | list | `[]` | Additional Volumes to use with Vector Pods. |
 | fullnameOverride | string | `""` | Override the full name of resources. |
+| image.base | string | `""` | The base distribution to use for vector. If set, then the base in appVersion will be replaced with this base alongside the version. For example: with a `base` of `debian` `0.38.0-distroless-libc` becomes `0.38.0-debian` |
 | image.pullPolicy | string | `"IfNotPresent"` | The [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) for Vector's image. |
 | image.pullSecrets | list | `[]` | The [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) to reference for the Vector Pods. |
 | image.repository | string | `"timberio/vector"` | Override default registry and name for Vector's image. |
 | image.sha | string | `""` | The SHA to use for Vector's image. |
 | image.tag | string | Derived from the Chart's appVersion. | The tag to use for Vector's image. |
-| image.base | string | `""` | The base distribution to use for vector. If set, then the base in appVersion will be replaced with this base alongside the version. For example: with a `base` of `debian` `0.38.0-distroless-libc` becomes `0.38.0-debian` |
 | ingress.annotations | object | `{}` | Set annotations on the Ingress. |
 | ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18 |
 | ingress.enabled | bool | `false` | If true, create and use an Ingress resource. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -156,6 +156,7 @@ helm install --name <RELEASE_NAME> \
 | image.repository | string | `"timberio/vector"` | Override default registry and name for Vector's image. |
 | image.sha | string | `""` | The SHA to use for Vector's image. |
 | image.tag | string | Derived from the Chart's appVersion. | The tag to use for Vector's image. |
+| image.base | string | `""` | The base distribution to use for vector. If set, then the base in appVersion will be replaced with this base alongside the version. For example: with a `base` of `debian` `0.38.0-distroless-libc` becomes `0.38.0-debian` |
 | ingress.annotations | object | `{}` | Set annotations on the Ingress. |
 | ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18 |
 | ingress.enabled | bool | `false` | If true, create and use an Ingress resource. |

--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -6,6 +6,25 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+  Set the image tag when `base` is used to allow for updates that are pinned
+  to a specific base OS, but not to a specific version.
+
+  This assumes that the `appVersion` has a prefix of the actual version followed
+  by the default OS.
+
+  A manual tag takes precedence over everything else
+*/}}
+{{- define "vector.image.tag" -}}
+{{- $version := .Chart.AppVersion }}
+{{- if .Values.image.tag }}
+{{- $version = .Values.image.tag }}
+{{- else if .Values.image.base }}
+{{- $version = (printf "%s-%s" (first (splitList "-" $version)) .Values.image.base) }}
+{{- end }}
+{{- printf "%s" $version }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
@@ -37,7 +56,7 @@ Common labels.
 helm.sh/chart: {{ include "vector.chart" . }}
 {{ include "vector.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ include "vector.image.tag" . | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ with .Values.commonLabels }}

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -38,9 +38,9 @@ containers:
 {{ toYaml . | indent 6 }}
 {{- end }}
 {{- if .Values.image.sha }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
+    image: "{{ .Values.image.repository }}:{{ include "vector.image.tag" . }}@sha256:{{ .Values.image.sha }}"
 {{- else }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+    image: "{{ .Values.image.repository }}:{{ include "vector.image.tag" . }}"
 {{- end }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- with .Values.command }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -38,6 +38,9 @@ image:
   tag: ""
   # image.sha -- The SHA to use for Vector's image.
   sha: ""
+  # image.base -- The base distribution to use for vector. If set, then the base in appVersion will be replaced with this base alongside the version.
+  # For example: with a `base` of `debian` `0.38.0-distroless-libc` becomes `0.38.0-debian`
+  base: ""
 
 # replicas -- Specify the number of Pods to create. Valid for the "Aggregator" and "Stateless-Aggregator" roles.
 replicas: 1


### PR DESCRIPTION
This fixes #237 by allowing the user of the chart to set a static `.Values.image.base` field.

When this is set, it will be used to replace the `base` that is used in the `AppVersion` where appropriate, so that users can upgrade their chart without having to constantly change the image tag to keep the version up.

The order of precedence for this is:
1. `.Values.image.tag` overrides everything
2. `.Values.image.base` overrides the base of the `.Chart.AppVersion`
3. `.Chart.AppVersion` is the default

I could not for the life of me get chart testing to work locally for some reason, but I am happy to update the README.md by hand if necessary.