### PR TITLE
fix(vector): Fix indentation for haproxy.initContainers

### DIFF
--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       {{- with .Values.haproxy.initContainers }}
       initContainers:
-        {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: haproxy


### PR DESCRIPTION
Hello friends!

I just encountered a small issue with the `vector` chart when trying to add an optional init-container for the HAProxy deployment. The line that expands `.Values.haproxy.initContainers` doesn't trim the initial whitespaces, causing the first line of the rendered YAML to have 16 spaces instead of the desired 8. 

Added a `{{-` to trim the initial whitespaces (and newline), and used `nindent` to add the newline again. This aligns with other expansions within this template :) 

This is my first PR, so please let me know if you need any additional info or if I need to change the commit message etc. Tried to keep it similar to the existing ones ;)  

Cheers!