### PR TITLE
feat(vector): Allow configuration of service port overrides via `vector.portsOverrides`

### DIFF
--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -129,6 +129,26 @@ Generate an array of ServicePorts based on `.Values.customConfig`.
 {{- end }}
 
 {{/*
+Returns a list of ports merged from services.portsOverrides and customConfigs.
+*/}}
+{{- define "vector.portsOverrides" -}}
+  {{- $mergedPorts := dict }}
+  {{- range $_, $svcPort := .Values.service.portsOverrides }}
+    {{- if not (hasKey $mergedPorts $svcPort.name) }}
+      {{- $_ := set $mergedPorts $svcPort.name $svcPort }}
+    {{- end }}
+  {{- end }}
+  {{- range $_, $customPort := (include "vector.ports" . | fromYamlArray) }}
+    {{- if (hasKey $mergedPorts $customPort.name) }}
+      {{- $_ := set $mergedPorts $customPort.name (get $mergedPorts $customPort.name | mergeOverwrite $customPort)}}
+    {{- else }}
+      {{- $_ := set $mergedPorts $customPort.name $customPort }}
+    {{- end }}
+  {{- end }}
+  {{- values $mergedPorts | toYaml }}
+{{- end }}
+
+{{/*
 Iterate over the components defined in `.Values.customConfig`.
 */}}
 {{- define "_helper.componentIter" -}}

--- a/charts/vector/templates/service-headless.yaml
+++ b/charts/vector/templates/service-headless.yaml
@@ -28,7 +28,11 @@ spec:
 {{- if or .Values.service.ports .Values.existingConfigMaps }}
   {{- toYaml .Values.service.ports | nindent 4 }}
 {{- else if .Values.customConfig }}
-  {{- include "vector.ports" . | indent 4 }}
+  {{- if .Values.service.portsOverrides  }}
+    {{- include "vector.portsOverrides" . | nindent 4 }}
+  {{- else }}
+    {{- include "vector.ports" . | indent 4 }}
+  {{- end }}
 {{- else }}
     - name: datadog-agent
       port: 8282

--- a/charts/vector/templates/service.yaml
+++ b/charts/vector/templates/service.yaml
@@ -32,7 +32,11 @@ spec:
 {{- if or .Values.service.ports .Values.existingConfigMaps }}
   {{- toYaml .Values.service.ports | nindent 4 }}
 {{- else if .Values.customConfig }}
-  {{- include "vector.ports" . | indent 4 }}
+  {{- if .Values.service.portsOverrides }}
+    {{- include "vector.portsOverrides" . | nindent 4}}
+  {{- else }}
+    {{- include "vector.ports" . | indent 4 }}
+  {{- end }}
 {{- else if or (eq .Values.role "Aggregator") (eq .Values.role "Stateless-Aggregator") }}
     - name: datadog-agent
       port: 8282

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -251,6 +251,11 @@ service:
   #   - "*"
   # service.ports -- Manually set the Service ports, overriding automated generation of Service ports.
   ports: []
+  # service.portsOverrides -- Override auto-generated Service ports.
+  # You must define the name field for each dictionary for proper merging.
+  portsOverrides: []
+  #   - name: vector
+  #     appProtocol: grpc
   # service.externalTrafficPolicy -- Specify the [externalTrafficPolicy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip).
   externalTrafficPolicy: ""
   # service.internalTrafficPolicy -- Specify the [internalTrafficPolicy]https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy).


### PR DESCRIPTION
This template is meant for those users that want the automatically generated port definitions in the Service manifests but also needs to make some overrides, or additions, to those definitions.

Example changes:

values.yaml
```yaml
service:
  portsOverrides:
    - name: vector
      appProtocol: grpc

customConfig:
  api:
    enabled: true
    address: 127.0.0.1:8686
  sources:
    vector:
      address: 0.0.0.0:6000
      type: vector
```

results in a Service like the following:

```yaml
kind: Service
clusterIP: None
ports:
  - appProtocol: grpc
    name: vector
    port: 6000
    protocol: TCP
    targetPort: 6000
  - name: api
    port: 8686
    protocol: TCP
    targetPort: 8686
selector:
  app.kubernetes.io/name: vector
  app.kubernetes.io/instance: release-name
  app.kubernetes.io/component: Aggregator
type: ClusterIP
```