### PR TITLE
fix(vector): Allow empty workloadResourceAnnotations

### DIFF
--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -5,8 +5,10 @@ metadata:
   name: {{ include "vector.fullname" . }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
+  {{- with .Values.workloadResourceAnnotations }}
   annotations:
-    {{- toYaml .Values.workloadResourceAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This prevents from settings empty annotations like `annotations: {}` which causes argocd to always see DaemonSet as out of sync, because a DaemonSet will get `deprecated.daemonset.template.generation` annotation anyways