### PR TITLE
feat(vector): Add option to roll vector pods on secrets and extra objects change

### DIFF
--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -32,6 +32,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
       {{- end }}
+      {{- if .Values.rollWorkloadSecrets }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if .Values.rollWorkloadExtraObjects }}
+        checksum/extraObjects: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
+      {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -33,6 +33,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
       {{- end }}
+      {{- if .Values.rollWorkloadSecrets }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if .Values.rollWorkloadExtraObjects }}
+        checksum/extraObjects: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
+      {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -41,6 +41,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
       {{- end }}
+      {{- if .Values.rollWorkloadSecrets }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if .Values.rollWorkloadExtraObjects }}
+        checksum/extraObjects: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
+      {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -20,6 +20,12 @@ role: "Aggregator"
 # rollWorkload -- Add a checksum of the generated ConfigMap to workload annotations.
 rollWorkload: true
 
+# rollWorkloadSecrets -- Add a checksum of the generated Secret to workload annotations.
+rollWorkloadSecrets: false
+
+# rollWorkloadExtraObjects -- Add a checksum of the generated ExtraObjects to workload annotations.
+rollWorkloadExtraObjects: false
+
 # commonLabels -- Add additional labels to all created resources.
 commonLabels: {}
 


### PR DESCRIPTION
Changes to secrets or extra manifests defined does not trigger a rolling restart.
This PR adds an option to do that.

Normally I would turn `.Values.rollWorkload` into an object, then defined something like this 
```yaml
rollWorkload:
  configMap: true
  secrets: false
  extraObjects: false
```
but that would be a breaking change. Maybe something to consider for the next major release of this chart.