### PR TITLE
fix(vector): Set podmonitor namespace

### DIFF
--- a/charts/vector/templates/podmonitor.yaml
+++ b/charts/vector/templates/podmonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "vector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- with .Values.podMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
This PR fixes an issue where the PodMonitor resource was missing the namespace declaration. Without the namespace being explicitly defined, the PodMonitor resource may be created in the wrong namespace, leading to potential monitoring issues or deployment inconsistencies.