### PR TITLE
fix(vector): Quote namespace strings

### DIFF
--- a/charts/vector/templates/podmonitor.yaml
+++ b/charts/vector/templates/podmonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "vector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- with .Values.podMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
This prevents errors when namespaces are "numeric"