### PR TITLE
feat(vector): allow templating pod annotations

### DIFF
--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
         checksum/extraObjects: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
       {{- end }}
       {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       labels:
         {{- include "vector.selectorLabels" . | nindent 8 }}

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         checksum/extraObjects: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
       {{- end }}
       {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       labels:
         {{- include "vector.selectorLabels" . | nindent 8 }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
         checksum/extraObjects: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
       {{- end }}
       {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       labels:
         {{- include "vector.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
Workload templates now render podAnnotations through tpl, so users can supply templated checksums (e.g. hashing external ConfigMaps) without chart changes. This is useful when no cluster access is available e.g. when using the rendered manifest pattern.