### PR TITLE
feat(vector): Include log format support

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -165,7 +165,8 @@ helm install <RELEASE_NAME> \
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. This also supports template content, which will eventually be converted to yaml. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
 | livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
-| logLevel | string | `"info"` |  |
+| logConfig.format | string | `"text"` |  |
+| logConfig.level | string | `"info"` |  |
 | minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
 | nodeSelector | object | `{}` | Configure a [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for Vector Pods. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -165,8 +165,8 @@ helm install <RELEASE_NAME> \
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. This also supports template content, which will eventually be converted to yaml. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
 | livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
-| logConfig.format | string | `"text"` |  |
-| logConfig.level | string | `"info"` |  |
+| logConfig.format | string | `"text"` | Set Vector's logging format |
+| logConfig.level | string | `"info"` | Set Vector's log level |
 | minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
 | nodeSelector | object | `{}` | Configure a [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for Vector Pods. |

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -53,7 +53,9 @@ containers:
 {{- end }}
     env:
       - name: VECTOR_LOG
-        value: "{{ .Values.logLevel | default "info" }}"
+        value: "{{ .Values.logConfig.level | default "info" }}"
+      - name: VECTOR_LOG_FORMAT
+        value: "{{ .Values.logConfig.format | default "text" }}"
 {{- if .Values.env }}
 {{- with .Values.env }}
     {{- toYaml . | nindent 6 }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -516,8 +516,12 @@ podMonitor:
   # podMonitor.honorTimestamps -- If true, honor_timestamps is set to true in the [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
   honorTimestamps: true
 
-# Log level for Vector.
-logLevel: "info"
+# Log configuration for Vector
+logConfig:
+  # Log level -- Set Vector's log level
+  level: "info"
+  # Log format -- Set Vector's logging format
+  format: "text"
 
 # Optional built-in HAProxy load balancer.
 haproxy:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -518,9 +518,9 @@ podMonitor:
 
 # Log configuration for Vector
 logConfig:
-  # Log level -- Set Vector's log level
+  # logConfig.level -- Set Vector's log level
   level: "info"
-  # Log format -- Set Vector's logging format
+  # logConfig.format -- Set Vector's logging format
   format: "text"
 
 # Optional built-in HAProxy load balancer.


### PR DESCRIPTION
The chart currently only supports `log level` which means that it needs to change the `log format` via env vars instead of the same manner as level. This PR supports the change in log format via this chart.  The only challenge is that it is a breaking change due to the naming convention. I thought to use `logFormat` to have it backwards compatibile but it is beneficial to have them under a single mapping/section.