### PR TITLE
fix(vector): add missing namespace to HPA and PDB templates

### DIFF
--- a/charts/vector/templates/haproxy/configmap.yaml
+++ b/charts/vector/templates/haproxy/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 data:

--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 spec:

--- a/charts/vector/templates/haproxy/hpa.yaml
+++ b/charts/vector/templates/haproxy/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 spec:

--- a/charts/vector/templates/haproxy/service.yaml
+++ b/charts/vector/templates/haproxy/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
   annotations:

--- a/charts/vector/templates/haproxy/serviceaccount.yaml
+++ b/charts/vector/templates/haproxy/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "haproxy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
   {{- with .Values.haproxy.serviceAccount.annotations }}

--- a/charts/vector/templates/hpa.yaml
+++ b/charts/vector/templates/hpa.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ template "autoscaling.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "vector.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
   annotations:

--- a/charts/vector/templates/pdb.yaml
+++ b/charts/vector/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vector.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
 spec:

--- a/charts/vector/templates/psp.yaml
+++ b/charts/vector/templates/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "vector.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
 spec:

--- a/charts/vector/templates/psp.yaml
+++ b/charts/vector/templates/psp.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "vector.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
### Description:

- ArgoCD v3.3 has updated to [kustomize v5.8.0](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/3.2-3.3/#kustomize-upgraded-to-580)
- kustomize v5.8.0 has changed the way kustomize handles helmCharts: https://github.com/kubernetes-sigs/kustomize/pull/5940 which has a nice tl;dr:

```
TL;DR

If you use Kustomize with Helm charts, ensure that your Helm templates explicitly set the namespace, for example:

metadata:
  namespace: {{ .Release.Namespace }}

If your charts already handle namespaces this way, this change should not introduce any breaking behavior.
```
Most of the resources in the Vector helm chart already include this namespace part, but not all of them, and rendering them using kustomize >= 5.8.0 leaves those resources w/o namespace