### PR TITLE
fix(vector): use haproxy podPriorityClassName in haproxy deployment

### DIFF
--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: {{ include "haproxy.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.haproxy.podSecurityContext | nindent 8 }}
-      {{- with .Values.priorityClassName }}
+      {{- with .Values.haproxy.podPriorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
       {{- if .Values.haproxy.initContainers }}


### PR DESCRIPTION
Fixes a bug in the vector chart HAProxy Deployment template where priorityClassName was incorrectly read from `.Values.priorityClassName` instead of `.Values.haproxy.podPriorityClassName`.

values.yaml and README document `haproxy.podPriorityClassName` as the HAProxy pod setting, but the template was using the global value.