### PR TITLE
fix(vector): set haproxy terminationGracePeriodSeconds on pod spec

### DIFF
--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -38,6 +38,7 @@ spec:
       serviceAccountName: {{ include "haproxy.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.haproxy.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.haproxy.terminationGracePeriodSeconds }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}


### PR DESCRIPTION
Fixes HAProxy Deployment rendering in the vector chart so `haproxy.terminationGracePeriodSeconds` is applied to the Pod spec.

Previously, `haproxy.terminationGracePeriodSeconds` only affected hard-stop-after in haproxy.cfg, but was not reflected in the Pod spec.
This change makes chart behavior consistent with the value’s intent and documentation.