### PR TITLE
feat(vector): default API bind and readiness for chart-managed config

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -106,6 +106,18 @@ customConfig:
           {{ print "{{ source_type }}" }}
 ```
 
+### API exposure and health probes
+
+When using chart-managed default configuration (without `customConfig` and `existingConfigMaps`),
+Vector's API listens on `0.0.0.0:8686`, and the chart applies a default readiness probe
+(`httpGet` on `/health` and port `api`).
+
+If you use `customConfig`, ensure `api.enabled`/`api.address` and probe settings are aligned
+with your configuration.
+
+As this API can expose internal state, restrict reachability with Kubernetes controls such as
+`NetworkPolicy` and carefully scoped Service/Ingress exposure.
+
 ## All configuration options
 
 The following table lists the configurable parameters of the Vector chart and their default values. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -202,7 +214,7 @@ helm install <RELEASE_NAME> \
 | psp.create | bool | `false` | If true, create a [PodSecurityPolicy](https://kubernetes.io/docs/concepts/security/pod-security-policy/) resource. PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25. Intended for use with the "Agent" role. |
 | rbac.create | bool | `true` | If true, create and use RBAC resources. Only valid for the "Agent" role. |
 | rbac.extraRules | list | `[]` | List of additional Kubernetes RBAC rules to append to the ClusterRole. Rules defined here are appended after the chart's standard rules. Each item must follow the Kubernetes ClusterRole rule syntax.  Example: extraRules:   - apiGroups: [""]     resources: ["nodes/metrics", "nodes/stats"]     verbs: ["get"] |
-| readinessProbe | object | `{}` | Override default readiness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
+| readinessProbe | object | `{}` | Override default readiness probe settings. If not set, this chart applies an HTTP readinessProbe (`/health` on `api`) for chart-managed default configs. If customConfig is used, requires customConfig.api.enabled to be set to true. |
 | replicas | int | `1` | Specify the number of Pods to create. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
 | resources | object | `{}` | Set Vector resource requests and limits. |
 | role | string | `"Aggregator"` | [Role](https://vector.dev/docs/setup/deployment/roles/) for this Vector instance, valid options are: "Agent", "Aggregator", and "Stateless-Aggregator". |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -110,7 +110,7 @@ customConfig:
 
 When using chart-managed default configuration (without `customConfig` and `existingConfigMaps`),
 Vector's API listens on `0.0.0.0:8686`, and the chart applies a default readiness probe
-(`httpGet` on `/health` and port `api`).
+(`httpGet` on `/health` and port `8686`).
 
 If you use `customConfig`, ensure `api.enabled`/`api.address` and probe settings are aligned
 with your configuration.
@@ -214,7 +214,7 @@ helm install <RELEASE_NAME> \
 | psp.create | bool | `false` | If true, create a [PodSecurityPolicy](https://kubernetes.io/docs/concepts/security/pod-security-policy/) resource. PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25. Intended for use with the "Agent" role. |
 | rbac.create | bool | `true` | If true, create and use RBAC resources. Only valid for the "Agent" role. |
 | rbac.extraRules | list | `[]` | List of additional Kubernetes RBAC rules to append to the ClusterRole. Rules defined here are appended after the chart's standard rules. Each item must follow the Kubernetes ClusterRole rule syntax.  Example: extraRules:   - apiGroups: [""]     resources: ["nodes/metrics", "nodes/stats"]     verbs: ["get"] |
-| readinessProbe | object | `{}` | Override default readiness probe settings. If not set, this chart applies an HTTP readinessProbe (`/health` on `api`) for chart-managed default configs. If customConfig is used, requires customConfig.api.enabled to be set to true. |
+| readinessProbe | object | `{}` | Override default readiness probe settings. If not set, this chart applies an HTTP readinessProbe (`/health` on port `8686`) for chart-managed default configs. If customConfig is used, requires customConfig.api.enabled to be set to true. |
 | replicas | int | `1` | Specify the number of Pods to create. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
 | resources | object | `{}` | Set Vector resource requests and limits. |
 | role | string | `"Aggregator"` | [Role](https://vector.dev/docs/setup/deployment/roles/) for this Vector instance, valid options are: "Agent", "Aggregator", and "Stateless-Aggregator". |

--- a/charts/vector/README.md.gotmpl
+++ b/charts/vector/README.md.gotmpl
@@ -104,6 +104,18 @@ customConfig:
           {{ print "{{ print \"{{ source_type }}\" }}" }}
 ```
 
+### API exposure and health probes
+
+When using chart-managed default configuration (without `customConfig` and `existingConfigMaps`),
+Vector's API listens on `0.0.0.0:8686`, and the chart applies a default readiness probe
+(`httpGet` on `/health` and port `api`).
+
+If you use `customConfig`, ensure `api.enabled`/`api.address` and probe settings are aligned
+with your configuration.
+
+As this API can expose internal state, restrict reachability with Kubernetes controls such as
+`NetworkPolicy` and carefully scoped Service/Ingress exposure.
+
 ## All configuration options
 
 The following table lists the configurable parameters of the Vector chart and their default values. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/charts/vector/README.md.gotmpl
+++ b/charts/vector/README.md.gotmpl
@@ -108,7 +108,7 @@ customConfig:
 
 When using chart-managed default configuration (without `customConfig` and `existingConfigMaps`),
 Vector's API listens on `0.0.0.0:8686`, and the chart applies a default readiness probe
-(`httpGet` on `/health` and port `api`).
+(`httpGet` on `/health` and port `8686`).
 
 If you use `customConfig`, ensure `api.enabled`/`api.address` and probe settings are aligned
 with your configuration.

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -129,7 +129,7 @@ containers:
     readinessProbe:
       httpGet:
         path: /health
-        port: api
+        port: 8686
 {{- end }}
 {{- with .Values.resources }}
     resources:

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -122,9 +122,14 @@ containers:
     livenessProbe:
       {{- toYaml . | trim | nindent 6 }}
 {{- end }}
-{{- with .Values.readinessProbe }}
+{{- if .Values.readinessProbe }}
     readinessProbe:
-      {{- toYaml . | trim | nindent 6 }}
+      {{- toYaml .Values.readinessProbe | trim | nindent 6 }}
+{{- else if and (not .Values.existingConfigMaps) (not .Values.customConfig) }}
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: api
 {{- end }}
 {{- with .Values.resources }}
     resources:

--- a/charts/vector/templates/configmap.yaml
+++ b/charts/vector/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
     data_dir: /vector-data-dir
     api:
       enabled: true
-      address: 127.0.0.1:8686
+      address: 0.0.0.0:8686
       playground: false
     sources:
       datadog_agent:
@@ -59,7 +59,7 @@ data:
     data_dir: /vector-data-dir
     api:
       enabled: true
-      address: 127.0.0.1:8686
+      address: 0.0.0.0:8686
       playground: false
     sources:
       kubernetes_logs:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -483,12 +483,12 @@ livenessProbe: {}
   #   port: api
 
 # readinessProbe -- Override default readiness probe settings. If not set, this chart applies an
-# HTTP readinessProbe (`/health` on `api`) for chart-managed default configs.
+# HTTP readinessProbe (`/health` on port `8686`) for chart-managed default configs.
 # If customConfig is used, requires customConfig.api.enabled to be set to true.
 readinessProbe: {}
   # httpGet:
   #   path: /health
-  #   port: api
+  #   port: 8686
 
 # Configure a PodMonitor for Vector, requires the PodMonitor CRD to be installed.
 podMonitor:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -482,8 +482,9 @@ livenessProbe: {}
   #   path: /health
   #   port: api
 
-# readinessProbe -- Override default readiness probe settings. If customConfig is used,
-# requires customConfig.api.enabled to be set to true.
+# readinessProbe -- Override default readiness probe settings. If not set, this chart applies an
+# HTTP readinessProbe (`/health` on `api`) for chart-managed default configs.
+# If customConfig is used, requires customConfig.api.enabled to be set to true.
 readinessProbe: {}
   # httpGet:
   #   path: /health


### PR DESCRIPTION
This PR updates the vector chart defaults to make health checks easier to use with chart-managed configuration.

* Changes default generated Vector config api.address from 127.0.0.1:8686 to 0.0.0.0:8686
* Adds a default readinessProbe only for chart-managed config (no customConfig / no existingConfigMaps)
  * httpGet.path: /health
  * httpGet.port: api
* Keeps livenessProbe opt-in (no default liveness behavior change)
* Updates README and values comments with API exposure and probe behavior notes

## Considerations

* This is a behavioral change for users relying on chart defaults: API bind changes from loopback-only to pod-reachable (0.0.0.0).
* Security impact: wider API reachability means access should be restricted with NetworkPolicy and careful Service/Ingress exposure (this PR intentionally does not add default NetworkPolicy resources).