### PR TITLE
chore(chart): bump minimum kubeVersion to 1.28 and remove legacy version guards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,13 +42,9 @@ jobs:
         # When changing versions here, check that the version exists at: https://github.com/yannh/kubernetes-json-schema and https://hub.docker.com/r/kindest/node/tags
         # Aim to match https://github.com/vectordotdev/vector/blob/master/.github/workflows/k8s_e2e.yml as close as possible
         k8s:
-          - v1.23.3
-          # fails on `kind` but not `minikube`; we weren't able to track down why
-          # possibly related to https://github.com/kubernetes-sigs/kind/issues/2532
-          # - v1.22.4
-          - v1.21.2
-          - v1.20.7
-          - v1.19.11
+          - v1.32.0
+          - v1.30.0
+          - v1.28.0
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -73,13 +69,9 @@ jobs:
         # When changing versions here, check that the version exists at: https://github.com/yannh/kubernetes-json-schema and https://hub.docker.com/r/kindest/node/tags
         # Aim to match https://github.com/vectordotdev/vector/blob/master/.github/workflows/k8s_e2e.yml as close as possible
         k8s:
-          - v1.23.3
-          # fails on `kind` but not `minikube`; we weren't able to track down why
-          # possibly related to https://github.com/kubernetes-sigs/kind/issues/2532
-          # - v1.22.4
-          - v1.21.2
-          - v1.20.7
-          - v1.19.11
+          - v1.32.0
+          - v1.30.0
+          - v1.28.0
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,9 @@ jobs:
         # When changing versions here, check that the version exists at: https://github.com/yannh/kubernetes-json-schema and https://hub.docker.com/r/kindest/node/tags
         # Aim to match https://github.com/vectordotdev/vector/blob/master/.github/workflows/k8s_e2e.yml as close as possible
         k8s:
+          - v1.35.0
+          - v1.34.0
+          - v1.33.0
           - v1.32.0
           - v1.30.0
           - v1.28.0
@@ -69,6 +72,9 @@ jobs:
         # When changing versions here, check that the version exists at: https://github.com/yannh/kubernetes-json-schema and https://hub.docker.com/r/kindest/node/tags
         # Aim to match https://github.com/vectordotdev/vector/blob/master/.github/workflows/k8s_e2e.yml as close as possible
         k8s:
+          - v1.35.0
+          - v1.34.0
+          - v1.33.0
           - v1.32.0
           - v1.30.0
           - v1.28.0

--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vector
 version: "0.52.0"
-kubeVersion: ">=1.15.0-0"
+kubeVersion: ">=1.28.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application
 keywords:

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -15,7 +15,7 @@ helm repo update
 
 ## Requirements
 
-Kubernetes: `>=1.15.0-0`
+Kubernetes: `>=1.28.0-0`
 
 ## Quick start
 

--- a/charts/vector/templates/_helpers.tpl
+++ b/charts/vector/templates/_helpers.tpl
@@ -140,22 +140,14 @@ Create the name of the service account to use.
 Return the appropriate apiVersion for PodDisruptionBudget policy APIs.
 */}}
 {{- define "policy.poddisruptionbudget.apiVersion" -}}
-{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) -}}
 "policy/v1"
-{{- else -}}
-"policy/v1beta1"
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for HPA autoscaling APIs.
 */}}
 {{- define "autoscaling.apiVersion" -}}
-{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") (semverCompare ">=1.23" .Capabilities.KubeVersion.Version) -}}
 "autoscaling/v2"
-{{- else -}}
-"autoscaling/v2beta2"
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/vector/templates/haproxy/_helpers.tpl
+++ b/charts/vector/templates/haproxy/_helpers.tpl
@@ -43,9 +43,5 @@ Create the name of the service account to use
 Return the appropriate apiVersion for HPA autoscaling APIs.
 */}}
 {{- define "autoscaling.apiVersion" -}}
-{{- if or (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") (semverCompare ">=1.23" .Capabilities.KubeVersion.Version) -}}
 "autoscaling/v2"
-{{- else -}}
-"autoscaling/v2beta2"
-{{- end -}}
 {{- end -}}

--- a/charts/vector/templates/ingress.yaml
+++ b/charts/vector/templates/ingress.yaml
@@ -1,16 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.Version)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "vector.fullname" . }}
@@ -22,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.Version) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -42,11 +31,10 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
+            {{- if .pathType }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
               service:
                 name: {{ if $.Values.haproxy.enabled }}{{ include "haproxy.fullname" $ }}{{ else }}{{ include "vector.fullname" $ }}{{ end }}
                 port:
@@ -55,10 +43,6 @@ spec:
                   {{- else }}
                   number: {{ .port.number }}
                   {{- end }}
-              {{- else }}
-              serviceName: {{ if $.Values.haproxy.enabled }}{{ include "haproxy.fullname" $ }}{{ else }}{{ include "vector.fullname" $ }}{{ end }}
-              servicePort: {{ .port.number }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -16,16 +16,14 @@ spec:
   replicas: {{ .Values.replicas }}
   {{- end }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.persistence.retentionPolicy) }}
+  {{- if .Values.persistence.retentionPolicy }}
   persistentVolumeClaimRetentionPolicy:
     {{ toYaml .Values.persistence.retentionPolicy | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "vector.selectorLabels" . | nindent 6 }}
-  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.Version }}
   minReadySeconds: {{ .Values.minReadySeconds }}
-  {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Summary

- Bumps `kubeVersion` in `Chart.yaml` from `>=1.15.0-0` to `>=1.28.0-0`, motivated by [vector#24699](https://github.com/vectordotdev/vector/pull/24699) which updated CI test versions from k8s 1.19–1.23 (EOL) to 1.31–1.35
- Removes all version-conditional template branches that existed to support Kubernetes < 1.24 (all long EOL)
- Now evaluating more versions based on  https://github.com/vectordotdev/vector/blob/master/.github/workflows/k8s_e2e.yml#L132-L138

## Why 1.28?

All template simplifications are valid at 1.28 — the oldest removed API (`autoscaling/v2beta2`, `policy/v1beta1`) was dropped upstream in 1.25–1.26, so any cluster on 1.28 was already exclusively using the new APIs. The old branches were dead code for them.

1.28 is also the most conservative defensible floor:

| Provider | 1.28 support ended |
|---|---|
| **GKE** | Feb 2025 |
| **EKS** | Nov 2025 (extended support) |
| **AKS LTS** | Feb 28, 2026 — just expired |
| **OpenShift 4.15** | Aug 2025 (no forced upgrades on-prem) |
| **VMware Tanzu on vCenter 7.x** | May 2025 |

AKS LTS 1.28 is the last major cloud provider to have dropped it, expiring just weeks ago. Anyone below 1.28 is on a version with no active cloud provider support and is very unlikely to be actively updating a Vector chart.

## Impact on existing users

### Version gate (`kubeVersion`)
Helm will **reject `install`/`upgrade`** on clusters running Kubernetes < 1.28. Given 1.27 and below is EOL everywhere, impact should be negligible.

### Template simplifications
**Completely transparent to all users on 1.28+.** Every API that was behind a version guard has been the only available version since well before 1.28:

| Change | API GA since | Old beta/deprecated API removed in |
|---|---|---|
| `networking.k8s.io/v1` for Ingress | k8s 1.19 | beta removed in 1.22 |
| `policy/v1` for PDB | k8s 1.21 | beta removed in 1.25 |
| `autoscaling/v2` for HPA | k8s 1.23 | beta removed in 1.26 |
| `minReadySeconds` on StatefulSet | k8s 1.22 | n/a |
| `persistentVolumeClaimRetentionPolicy` on StatefulSet | k8s 1.23 | n/a |

No behavior change for any user on a supported cluster.

## Test plan

- [x] `helm template` renders correctly against a 1.28+ cluster
- [ ] Verify `helm install`/`upgrade` is rejected on clusters < 1.28 (Helm kubeVersion enforcement)
- [ ] Confirm ingress, statefulset, PDB, and HPA manifests render with the correct API versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)