### PR TITLE
feat(vector): add startupProbe option to pod template

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -228,6 +228,7 @@ helm install <RELEASE_NAME> \
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and serviceAccount.create is true, a name is generated using the fullname template. |
 | serviceHeadless.enabled | bool | `true` | If true, create and provide a Headless Service resource for Vector. |
 | shareProcessNamespace | bool | `false` | Specify the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) options for Vector Pods. |
+| startupProbe | object | `{}` | Override default startup probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe instead of httpGet. |
 | terminationGracePeriodSeconds | int | `60` | Override Vector's terminationGracePeriodSeconds. |
 | tolerations | list | `[]` | Configure Vector Pods to be scheduled on [tainted](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) nodes. |
 | topologySpreadConstraints | list | `[]` | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for Vector Pods. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -126,6 +126,10 @@ containers:
     readinessProbe:
       {{- toYaml . | trim | nindent 6 }}
 {{- end }}
+{{- with .Values.startupProbe }}
+    startupProbe:
+      {{- toYaml . | trim | nindent 6 }}
+{{- end }}
 {{- with .Values.resources }}
     resources:
 {{- toYaml . | nindent 6 }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -487,6 +487,13 @@ readinessProbe: {}
   # grpc:
   #   port: 8686
 
+# startupProbe -- Override default startup probe settings. If customConfig is used,
+# requires customConfig.api.enabled to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe
+# instead of httpGet.
+startupProbe: {}
+  # grpc:
+  #   port: 8686
+
 # Configure a PodMonitor for Vector, requires the PodMonitor CRD to be installed.
 podMonitor:
   # podMonitor.enabled -- If true, create a PodMonitor for Vector.


### PR DESCRIPTION
**Description**
Allows Vector to be configured with a [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) in the same way that it can be set for `livenessProbes` and `readinessProbes`

**Testing steps**
```
- With the default values.yaml, the startupProbe settings do not show within the Pod Spec. Can be seen when running `helm template`
- When setting the startupProbe values, the settings show within the Pod Spec when running `helm template`.
```