### PR TITLE
feat(vector): add support for custom annotations on sts pvc

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -170,6 +170,7 @@ helm install <RELEASE_NAME> \
 | nameOverride | string | `""` | Override the name of resources. |
 | nodeSelector | object | `{}` | Configure a [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for Vector Pods. |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role. |
+| persistence.annotations | object | `{}` | Set annotations on the PersistentVolumeClaims created by the StatefulSet. |
 | persistence.enabled | bool | `false` | If true, create and use PersistentVolumeClaims. |
 | persistence.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim to use. Valid for the "Aggregator" role. |
 | persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Specifies the finalizers of PersistentVolumeClaims. Valid for the "Aggregator" role. |

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -63,6 +63,10 @@ spec:
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   - metadata:
       name: data
+      {{- with .Values.persistence.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       accessModes: {{ .Values.persistence.accessModes }}
       {{- if .Values.persistence.storageClassName }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -435,6 +435,9 @@ persistence:
   #  whenDeleted: Retain
   #  whenScaled: Retain
 
+  # persistence.annotations -- Set annotations on the PersistentVolumeClaims created by the StatefulSet.
+  annotations: {}
+
   # persistence.accessModes -- Specifies the accessModes for PersistentVolumeClaims. Valid for the "Aggregator" role.
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
## Changes

Adds a new `persistence.annotations` value that allows setting custom annotations on PVCs created by the Vector StatefulSet.

Fixes #551

## Testing

Tested by using `helm template` on a slightly modified version of the statefulset yaml (only removed includes to simplify values I needed to set for testing).

<details><summary>Template used for testing</summary>

```yaml
{{- if (eq .Values.role "Aggregator") -}}
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test
  namespace: {{ .Release.Namespace | quote }}
  labels: {}
  annotations:
    {{- toYaml .Values.workloadResourceAnnotations | nindent 4 }}
spec:
  {{- with .Values.revisionHistoryLimit }}
  revisionHistoryLimit: {{ . }}
  {{- end }}
  {{- if not (or .Values.autoscaling.enabled .Values.autoscaling.external) }}
  replicas: {{ .Values.replicas }}
  {{- end }}
  podManagementPolicy: {{ .Values.podManagementPolicy }}
  {{- if .Values.persistence.retentionPolicy }}
  persistentVolumeClaimRetentionPolicy:
    {{ toYaml .Values.persistence.retentionPolicy | nindent 4 }}
  {{- end }}
  selector:
    matchLabels: {}
  minReadySeconds: {{ .Values.minReadySeconds }}
  {{- with .Values.updateStrategy }}
  updateStrategy:
    {{- toYaml . | nindent 4 }}
  {{- end }}
  serviceName: test-headless
  template:
    metadata:
      annotations:
      {{- if .Values.rollWorkload }}
        {{- if .Values.existingConfigMaps }}
          {{- range .Values.existingConfigMaps }}
            {{- range $file, $contents := (lookup "v1" "ConfigMap" (print $.Release.Namespace) (print .)).data }}
        checksum/{{ $file }}: {{ $contents | sha256sum }}
            {{- end }}
          {{- end }}
        {{- else }}
        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
        {{- end }}
      {{- end }}
      {{- if .Values.rollWorkloadSecrets }}
        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
      {{- end }}
      {{- if .Values.rollWorkloadExtraObjects }}
        checksum/extraObjects: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
      {{- end }}
      {{- with .Values.podAnnotations }}
        {{- toYaml . | nindent 8 }}
      {{- end }}
      labels: {}
      {{- with .Values.podLabels }}
        {{- toYaml . | nindent 8 }}
      {{- end }}
    spec: {}
  volumeClaimTemplates:
{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
  - metadata:
      name: data
      {{- with .Values.persistence.annotations }}
      annotations:
        {{- toYaml . | nindent 8 }}
      {{- end }}
    spec:
      accessModes: {{ .Values.persistence.accessModes }}
      {{- if .Values.persistence.storageClassName }}
      storageClassName: {{ .Values.persistence.storageClassName }}
      {{- end }}
      resources:
        requests:
          storage: {{ .Values.persistence.size }}
      {{- with .Values.persistence.selector }}
      selector:
{{ toYaml . | indent 8 }}
      {{- end }}
{{- end }}
{{- end }}
```

</details>

<details><summary>Default value (`{}`)</summary>

```yaml
# Values.yaml
role: Aggregator
workloadResourceAnnotations: {}
persistence:
  enabled: true
  annotations: {}
```

```yaml
# Output
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test
  namespace: "example"
  labels: {}
  annotations:
    {}
spec:
  replicas: <no value>
  podManagementPolicy: <no value>
  selector:
    matchLabels: {}
  minReadySeconds: <no value>
  serviceName: test-headless
  template:
    metadata:
      annotations:
      labels: {}
    spec: {}
  volumeClaimTemplates:
  - metadata:
      name: data
    spec:
      accessModes: <no value>
      resources:
        requests:
          storage: <no value>
```

</details>

<details><summary>Custom annotations set</summary>

```yaml
# Values.yaml
role: Aggregator
workloadResourceAnnotations: {}
persistence:
  enabled: true
  annotations:
    my-annotation: test
```

```yaml
# Output
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test
  namespace: "example"
  labels: {}
  annotations:
    {}
spec:
  replicas: <no value>
  podManagementPolicy: <no value>
  selector:
    matchLabels: {}
  minReadySeconds: <no value>
  serviceName: test-headless
  template:
    metadata:
      annotations:
      labels: {}
    spec: {}
  volumeClaimTemplates:
  - metadata:
      name: data
      annotations:
        my-annotation: test
    spec:
      accessModes: <no value>
      resources:
        requests:
          storage: <no value>
```

</details> 