### PR TITLE
fix(chart)!: update health probe examples to use gRPC

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -164,7 +164,7 @@ helm install <RELEASE_NAME> \
 | ingress.tls | list | `[]` | Configure TLS for the Ingress. |
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. This also supports template content, which will eventually be converted to yaml. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
-| livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
+| livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe instead of httpGet. |
 | logLevel | string | `"info"` |  |
 | minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
@@ -202,7 +202,7 @@ helm install <RELEASE_NAME> \
 | psp.create | bool | `false` | If true, create a [PodSecurityPolicy](https://kubernetes.io/docs/concepts/security/pod-security-policy/) resource. PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25. Intended for use with the "Agent" role. |
 | rbac.create | bool | `true` | If true, create and use RBAC resources. Only valid for the "Agent" role. |
 | rbac.extraRules | list | `[]` | List of additional Kubernetes RBAC rules to append to the ClusterRole. Rules defined here are appended after the chart's standard rules. Each item must follow the Kubernetes ClusterRole rule syntax.  Example: extraRules:   - apiGroups: [""]     resources: ["nodes/metrics", "nodes/stats"]     verbs: ["get"] |
-| readinessProbe | object | `{}` | Override default readiness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. |
+| readinessProbe | object | `{}` | Override default readiness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe instead of httpGet. |
 | replicas | int | `1` | Specify the number of Pods to create. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
 | resources | object | `{}` | Set Vector resource requests and limits. |
 | role | string | `"Aggregator"` | [Role](https://vector.dev/docs/setup/deployment/roles/) for this Vector instance, valid options are: "Agent", "Aggregator", and "Stateless-Aggregator". |

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -476,18 +476,17 @@ dnsConfig: {}
 shareProcessNamespace: false
 
 # livenessProbe -- Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled
-# to be set to true.
+# to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe instead of httpGet.
 livenessProbe: {}
-  # httpGet:
-  #   path: /health
-  #   port: api
+  # grpc:
+  #   port: 8686
 
 # readinessProbe -- Override default readiness probe settings. If customConfig is used,
-# requires customConfig.api.enabled to be set to true.
+# requires customConfig.api.enabled to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe
+# instead of httpGet.
 readinessProbe: {}
-  # httpGet:
-  #   path: /health
-  #   port: api
+  # grpc:
+  #   port: 8686
 
 # Configure a PodMonitor for Vector, requires the PodMonitor CRD to be installed.
 podMonitor:


### PR DESCRIPTION
## Summary

Documentation only change.

- Update commented-out liveness/readiness probe examples in `values.yaml` from `httpGet` to `grpc`
- Vector's API is now gRPC-only (HTTP/2) after vectordotdev/vector#24364, so `httpGet` probes no longer work against the `/health` endpoint
- gRPC health probes are the standard for gRPC services in K8s.

## References

- https://github.com/vectordotdev/vector/pull/24995#issuecomment-4175975606

🤖 Generated with [Claude Code](https://claude.com/claude-code)