### PR TITLE
chore(chart): remove `playground` from default API config

### DIFF
--- a/charts/vector/examples/datadog-values.yaml
+++ b/charts/vector/examples/datadog-values.yaml
@@ -78,7 +78,6 @@ customConfig:
   api:
     enabled: true
     address: 0.0.0.0:8686
-    playground: false
   sources:
     datadog_agent:
       address: 0.0.0.0:8282

--- a/charts/vector/templates/configmap.yaml
+++ b/charts/vector/templates/configmap.yaml
@@ -16,7 +16,6 @@ data:
     api:
       enabled: true
       address: 127.0.0.1:8686
-      playground: false
     sources:
       datadog_agent:
         address: 0.0.0.0:8282
@@ -60,7 +59,6 @@ data:
     api:
       enabled: true
       address: 127.0.0.1:8686
-      playground: false
     sources:
       kubernetes_logs:
         type: kubernetes_logs

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -337,7 +337,6 @@ customConfig: {}
   # api:
   #   enabled: true
   #   address: 127.0.0.1:8686
-  #   playground: false
   # sources:
   #   vector:
   #     address: 0.0.0.0:6000


### PR DESCRIPTION
## Summary

- Remove the `playground` field from default API configs in the Aggregator, Agent, and Datadog example templates
- This field was removed from Vector's API in vectordotdev/vector#24364 (GraphQL-to-gRPC migration)
- Vector now rejects the unknown field on startup, causing pods to crash-loop with: `Configuration error. error=unknown field 'playground', expected 'enabled' or 'address'`

## Verification

Tested locally with minikube + `timberio/vector:nightly-debian`:
- **Before fix:** pod crash-loops with config error
- **After fix:** pod starts successfully (1/1 Running, 0 restarts)

## References

- vectordotdev/vector#25111
- vectordotdev/vector#24364

🤖 Generated with [Claude Code](https://claude.com/claude-code)