### PR TITLE
chore(chart): clarify health probes support both grpc and httpGet

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -177,7 +177,7 @@ helm install <RELEASE_NAME> \
 | ingress.tls | list | `[]` | Configure TLS for the Ingress. |
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. This also supports template content, which will eventually be converted to yaml. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
-| livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. `grpc` is recommended; the `httpGet /health` probe is kept for backwards compatibility. |
+| livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. `grpc` is recommended once the cluster is on Vector 0.55+; the `httpGet /health` probe is kept for backwards compatibility with older Vector versions. |
 | logLevel | string | `"info"` |  |
 | minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
@@ -215,7 +215,7 @@ helm install <RELEASE_NAME> \
 | psp.create | bool | `false` | If true, create a [PodSecurityPolicy](https://kubernetes.io/docs/concepts/security/pod-security-policy/) resource. PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25. Intended for use with the "Agent" role. |
 | rbac.create | bool | `true` | If true, create and use RBAC resources. Only valid for the "Agent" role. |
 | rbac.extraRules | list | `[]` | List of additional Kubernetes RBAC rules to append to the ClusterRole. Rules defined here are appended after the chart's standard rules. Each item must follow the Kubernetes ClusterRole rule syntax.  Example: extraRules:   - apiGroups: [""]     resources: ["nodes/metrics", "nodes/stats"]     verbs: ["get"] |
-| readinessProbe | object | `{}` | Override default readiness probe settings. If not set, this chart applies a gRPC readinessProbe on port `8686` for chart-managed default configs. If customConfig is used, requires customConfig.api.enabled to be set to true. |
+| readinessProbe | object | `{}` | Override default readiness probe settings. If not set, this chart applies an `httpGet /health` readinessProbe on port `8686` for chart-managed default configs. If customConfig is used, requires customConfig.api.enabled to be set to true. `grpc` is recommended once the cluster is on Vector 0.55+; the `httpGet /health` probe is kept for backwards compatibility with older Vector versions. |
 | replicas | int | `1` | Specify the number of Pods to create. Valid for the "Aggregator" and "Stateless-Aggregator" roles. |
 | resources | object | `{}` | Set Vector resource requests and limits. |
 | role | string | `"Aggregator"` | [Role](https://vector.dev/docs/setup/deployment/roles/) for this Vector instance, valid options are: "Agent", "Aggregator", and "Stateless-Aggregator". |
@@ -241,7 +241,7 @@ helm install <RELEASE_NAME> \
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and serviceAccount.create is true, a name is generated using the fullname template. |
 | serviceHeadless.enabled | bool | `true` | If true, create and provide a Headless Service resource for Vector. |
 | shareProcessNamespace | bool | `false` | Specify the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) options for Vector Pods. |
-| startupProbe | object | `{}` | Override default startup probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. `grpc` is recommended; the `httpGet /health` probe is kept for backwards compatibility. |
+| startupProbe | object | `{}` | Override default startup probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. `grpc` is recommended once the cluster is on Vector 0.55+; the `httpGet /health` probe is kept for backwards compatibility with older Vector versions. |
 | statefulSet.apiVersion | string | `""` | Override the StatefulSet apiVersion. Valid for the "Aggregator" role. |
 | terminationGracePeriodSeconds | int | `60` | Override Vector's terminationGracePeriodSeconds. |
 | tolerations | list | `[]` | Configure Vector Pods to be scheduled on [tainted](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) nodes. |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -177,7 +177,7 @@ helm install <RELEASE_NAME> \
 | ingress.tls | list | `[]` | Configure TLS for the Ingress. |
 | initContainers | list | `[]` | Init Containers to be added to the Vector Pods. This also supports template content, which will eventually be converted to yaml. |
 | lifecycle | object | `{}` | Set lifecycle hooks for Vector containers. |
-| livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe instead of httpGet. |
+| livenessProbe | object | `{}` | Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. `grpc` is recommended; the `httpGet /health` probe is kept for backwards compatibility. |
 | logLevel | string | `"info"` |  |
 | minReadySeconds | int | `0` | Specify the minimum number of seconds a newly spun up pod should wait to pass healthchecks before it is considered available. |
 | nameOverride | string | `""` | Override the name of resources. |
@@ -241,7 +241,7 @@ helm install <RELEASE_NAME> \
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and serviceAccount.create is true, a name is generated using the fullname template. |
 | serviceHeadless.enabled | bool | `true` | If true, create and provide a Headless Service resource for Vector. |
 | shareProcessNamespace | bool | `false` | Specify the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) options for Vector Pods. |
-| startupProbe | object | `{}` | Override default startup probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe instead of httpGet. |
+| startupProbe | object | `{}` | Override default startup probe settings. If customConfig is used, requires customConfig.api.enabled to be set to true. `grpc` is recommended; the `httpGet /health` probe is kept for backwards compatibility. |
 | statefulSet.apiVersion | string | `""` | Override the StatefulSet apiVersion. Valid for the "Aggregator" role. |
 | terminationGracePeriodSeconds | int | `60` | Override Vector's terminationGracePeriodSeconds. |
 | tolerations | list | `[]` | Configure Vector Pods to be scheduled on [tainted](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) nodes. |

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -127,7 +127,8 @@ containers:
       {{- toYaml .Values.readinessProbe | trim | nindent 6 }}
 {{- else if and (not .Values.existingConfigMaps) (not .Values.customConfig) }}
     readinessProbe:
-      grpc:
+      httpGet:
+        path: /health
         port: 8686
 {{- end }}
 {{- with .Values.startupProbe }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -485,9 +485,10 @@ dnsConfig: {}
 shareProcessNamespace: false
 
 # livenessProbe -- Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled
-# to be set to true. `grpc` is recommended; the `httpGet /health` probe is kept for backwards compatibility.
+# to be set to true. `grpc` is recommended once the cluster is on Vector 0.55+; the `httpGet /health` probe is kept
+# for backwards compatibility with older Vector versions.
 livenessProbe: {}
-  # Option 1: gRPC probe (uses grpc.health.v1.Health/Check)
+  # Option 1: gRPC probe (uses grpc.health.v1.Health/Check, requires Vector 0.55+)
   # grpc:
   #   port: 8686
   #
@@ -496,18 +497,25 @@ livenessProbe: {}
   #   path: /health
   #   port: 8686
 
-# readinessProbe -- Override default readiness probe settings. If not set, this chart applies a
-# gRPC readinessProbe on port `8686` for chart-managed default configs. If customConfig is used,
-# requires customConfig.api.enabled to be set to true.
+# readinessProbe -- Override default readiness probe settings. If not set, this chart applies an
+# `httpGet /health` readinessProbe on port `8686` for chart-managed default configs. If customConfig is used,
+# requires customConfig.api.enabled to be set to true. `grpc` is recommended once the cluster is on Vector 0.55+;
+# the `httpGet /health` probe is kept for backwards compatibility with older Vector versions.
 readinessProbe: {}
+  # Option 1: gRPC probe (uses grpc.health.v1.Health/Check, requires Vector 0.55+)
   # grpc:
+  #   port: 8686
+  #
+  # Option 2: HTTP probe
+  # httpGet:
+  #   path: /health
   #   port: 8686
 
 # startupProbe -- Override default startup probe settings. If customConfig is used,
-# requires customConfig.api.enabled to be set to true. `grpc` is recommended; the `httpGet /health` probe is kept
-# for backwards compatibility.
+# requires customConfig.api.enabled to be set to true. `grpc` is recommended once the cluster is on Vector 0.55+;
+# the `httpGet /health` probe is kept for backwards compatibility with older Vector versions.
 startupProbe: {}
-  # Option 1: gRPC probe (uses grpc.health.v1.Health/Check)
+  # Option 1: gRPC probe (uses grpc.health.v1.Health/Check, requires Vector 0.55+)
   # grpc:
   #   port: 8686
   #

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -485,9 +485,15 @@ dnsConfig: {}
 shareProcessNamespace: false
 
 # livenessProbe -- Override default liveness probe settings. If customConfig is used, requires customConfig.api.enabled
-# to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe instead of httpGet.
+# to be set to true. `grpc` is recommended; the `httpGet /health` probe is kept for backwards compatibility.
 livenessProbe: {}
+  # Option 1: gRPC probe (uses grpc.health.v1.Health/Check)
   # grpc:
+  #   port: 8686
+  #
+  # Option 2: HTTP probe
+  # httpGet:
+  #   path: /health
   #   port: 8686
 
 # readinessProbe -- Override default readiness probe settings. If not set, this chart applies a
@@ -498,10 +504,16 @@ readinessProbe: {}
   #   port: 8686
 
 # startupProbe -- Override default startup probe settings. If customConfig is used,
-# requires customConfig.api.enabled to be set to true. Since Vector's API is gRPC-only (HTTP/2), use a grpc probe
-# instead of httpGet.
+# requires customConfig.api.enabled to be set to true. `grpc` is recommended; the `httpGet /health` probe is kept
+# for backwards compatibility.
 startupProbe: {}
+  # Option 1: gRPC probe (uses grpc.health.v1.Health/Check)
   # grpc:
+  #   port: 8686
+  #
+  # Option 2: HTTP probe
+  # httpGet:
+  #   path: /health
   #   port: 8686
 
 # Configure a PodMonitor for Vector, requires the PodMonitor CRD to be installed.


### PR DESCRIPTION
## Summary

HTTP `GET /health` was restored on Vector's API port in vectordotdev/vector#25234. The existing comments on `livenessProbe` / `startupProbe` in `values.yaml` need to be updated to reflect this.

### Additional fix: revert default readiness probe to `httpGet /health`

PR #540 pre-emptively switched the chart-managed default readiness probe to a gRPC probe (`grpc port: 8686`), but Vector 0.55 has not shipped yet. This PR reverts the default readiness probe to `httpGet /health` so `install-chart` passes against the pinned `appVersion`. 

Note: I also fixed the CI by adding missing required checks which allowed PR #540 to be merged in the first place.

## Testing steps

- Doc comments updated in `values.yaml`; `README.md` regenerated via `helm-docs`.
- Default readiness probe reverted in `charts/vector/templates/_pod.tpl`.
- Local: `helm lint`, `ct lint --config .github/ct.yaml`, and `kubeconform -strict` against all `charts/vector/ci/*-values.yaml` pass.

## References

- vectordotdev/vector#25234 — restores HTTP `GET /health`
- #540 — PR that introduced the premature `grpc` default readiness probe
- #553 — PR that introduced the "gRPC-only" wording
- vectordotdev/vector#24364 — adds gRPC health service (unreleased, ships in 0.55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)