### PR TITLE
feat(releasing): lockstep chart version with Vector version

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.53.0"
+version: "0.55.0"
 kubeVersion: ">=1.28.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.53.0](https://img.shields.io/badge/Version-0.53.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.55.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.55.0--distroless--libc-informational?style=flat-square)
+![Version: 0.55.0](https://img.shields.io/badge/Version-0.55.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.55.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.55.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 


### PR DESCRIPTION
## Summary

- Bumps the Vector chart `version` from `0.53.0` to `0.55.0` so it matches the current `appVersion` (Vector v0.55.0).
- Going forward, chart releases will track the Vector release version one-to-one.

closes: #502

## Test plan

- [x] Confirm `helm-docs` output (`charts/vector/README.md`) reflects the new version.
- [ ] Confirm the next release run picks up `0.55.0` and the post-release minor bump aligns with the next Vector release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)