### PR TITLE
fix(releasing): bump develop chart version to 0.56.0

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.55.0"
+version: "0.56.0"
 kubeVersion: ">=1.28.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.55.0](https://img.shields.io/badge/Version-0.55.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.55.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.55.0--distroless--libc-informational?style=flat-square)
+![Version: 0.56.0](https://img.shields.io/badge/Version-0.55.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.55.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.55.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.56.0](https://img.shields.io/badge/Version-0.55.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.55.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.55.0--distroless--libc-informational?style=flat-square)
+![Version: 0.56.0](https://img.shields.io/badge/Version-0.56.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.55.0-distroless-libc](https://img.shields.io/badge/AppVersion-0.55.0--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 


### PR DESCRIPTION
## Summary

`develop` chart version was left at `0.55.0` after PR #561 merged — it should be one step ahead at `0.56.0` so the helm release PR for Vector 0.56.0 picks up the correct chart version.

## Context

PR #561 lockstepped chart version with Vector version by bumping to `0.55.0`, but the post-release minor bump only brought `develop` to `0.56.0` — which is the same as the upcoming release. This PR corrects that so `develop` stays one step ahead as intended.