### PR TITLE
fix(releasing): fix post-release workflow master merge and add workflow_dispatch

### DIFF
--- a/.github/workflows/release-post.yml
+++ b/.github/workflows/release-post.yml
@@ -42,11 +42,15 @@ jobs:
 
       - name: Merge develop into master
         run: |
+          CHART_VERSION=$(grep '^version:' charts/vector/Chart.yaml | sed 's/version: "\(.*\)"/\1/')
+          SYNC_BRANCH="release-sync/${CHART_VERSION}"
+          git checkout -b "$SYNC_BRANCH"
+          git push origin "$SYNC_BRANCH"
           PR_URL=$(gh pr create \
-            --title "chore(releasing): Merge develop into master" \
-            --body "Post release: sync master with the latest release changes from develop." \
+            --title "chore(releasing): Merge develop into master for ${CHART_VERSION}" \
+            --body "Post release: sync master with the release changes from develop for ${CHART_VERSION}." \
             --base master \
-            --head develop)
+            --head "$SYNC_BRANCH")
           gh pr merge "$PR_URL" --auto --squash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-post.yml
+++ b/.github/workflows/release-post.yml
@@ -5,6 +5,11 @@ on:
     types: [closed]
     branches: [develop]
   workflow_dispatch:
+    inputs:
+      release_ref:
+        description: 'Git ref (branch or commit SHA) to sync to master, e.g. release-0.56.0'
+        required: true
+        type: string
 
 jobs:
   post-release:
@@ -26,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: develop
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || 'develop' }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/release-post.yml
+++ b/.github/workflows/release-post.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     types: [closed]
     branches: [develop]
+  workflow_dispatch:
 
 jobs:
   post-release:
-    # Only run when a release-* branch is merged into develop
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-')
+    # Only run when a release-* branch is merged into develop, or manually triggered
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -41,11 +42,14 @@ jobs:
 
       - name: Merge develop into master
         run: |
-          git fetch origin master
-          git switch master
-          git pull
-          git merge develop
-          git push origin master
+          PR_URL=$(gh pr create \
+            --title "chore(releasing): Merge develop into master" \
+            --body "Post release: sync master with the latest release changes from develop." \
+            --base master \
+            --head develop)
+          gh pr merge "$PR_URL" --auto --squash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Read and bump chart version
         id: version

--- a/.github/workflows/release-post.yml
+++ b/.github/workflows/release-post.yml
@@ -51,7 +51,7 @@ jobs:
             --body "Post release: sync master with the release changes from develop for ${CHART_VERSION}." \
             --base master \
             --head "$SYNC_BRANCH")
-          gh pr merge "$PR_URL" --auto --squash
+          gh pr merge "$PR_URL" --auto --merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
The post-release workflow was failing when trying to push directly to `master` because:

1. The bot is not in the push restrictions allowlist (only the `Vector` team can push directly).
2. The 4 required status checks (`pr-validated`, `lint-chart`, `lint-docs`, `install-chart`) only run on PRs, not direct pushes.

The "Merge develop into master" step now opens a PR and enables auto-merge (squash, to satisfy `required_linear_history`). The bot is already in `bypass_pull_request_allowances` so no human reviewer is needed once CI passes.

Also adds `workflow_dispatch` so the workflow can be re-run manually if needed.