### PR TITLE
docs: Redirect helm.vector.dev root to the Helm installation docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting to the Vector Helm installation docs</title>
+    <link
+      rel="canonical"
+      href="https://vector.dev/docs/setup/installation/package-managers/helm/"
+    />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://vector.dev/docs/setup/installation/package-managers/helm/"
+    />
+    <meta name="robots" content="noindex" />
+  </head>
+  <body>
+    <p>
+      This is the Helm chart repository for
+      <a href="https://vector.dev/">Vector</a>. Redirecting to the
+      <a href="https://vector.dev/docs/setup/installation/package-managers/helm/"
+        >installation documentation</a
+      >&hellip;
+    </p>
+    <p><code>helm repo add vector https://helm.vector.dev</code></p>
+  </body>
+</html>


### PR DESCRIPTION
## Motivation

`https://helm.vector.dev/` currently returns GitHub's default "Page not found" page, because the `gh-pages` branch contains only `index.yaml`, `artifacthub-repo.yml` and `CNAME`. A bare 404 at the root reads as an unclaimed GitHub Pages site, which is how this subdomain came to be reported as a dangling record.

Serving something real at the root makes it self-evident that the domain is ours and in active use.

## Changes

Adds an `index.html` that redirects to [the Helm installation docs](https://vector.dev/docs/setup/installation/package-managers/helm/), which already document this repository as the chart source. Redirecting rather than writing a landing page keeps the install instructions in one place.

The redirect is a `<meta http-equiv="refresh">` with a matching `rel="canonical"`, since GitHub Pages serves static files and cannot issue a server-side 301. A visible fallback link and the `helm repo add` command are included for clients that don't follow it — note that `curl` will not, so this is a browser-facing convenience rather than a true redirect.

## Notes

- `CNAME` is deliberately untouched. It holds the domain this site is *served at* (`helm.vector.dev`), which is correct — it is not a DNS target, and changing it would release our Pages claim on the subdomain.
- `chart-releaser` only rewrites `index.yaml`, so this file persists across releases the same way `CNAME` and `artifacthub-repo.yml` already do.
- Helm and Artifact Hub request `/index.yaml` and `/artifacthub-repo.yml` directly and are unaffected by the root document. Verified against the live domain that the repo still resolves (`helm repo add` + `helm search repo` returns 0.57.0).

The DNS record itself is fixed separately — it is not in this repo.