### PR TITLE
feat(vector): add service loadBalancerSourceRanges field

### DIFF
--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -233,6 +233,7 @@ helm install <RELEASE_NAME> \
 | service.ipFamilies | list | `[]` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
 | service.ipFamilyPolicy | string | `""` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
 | service.loadBalancerIP | string | `""` | Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer). |
+| service.loadBalancerSourceRanges | list | `[]` | Specify the [loadBalancerSourceRanges](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service) to restrict client IP ranges that can access the LoadBalancer Service. |
 | service.ports | list | `[]` | Manually set the Service ports, overriding automated generation of Service ports. |
 | service.topologyKeys | list | `[]` | Specify the [topologyKeys](https://kubernetes.io/docs/concepts/services-networking/service-topology/#using-service-topology) field on Vector's Service. |
 | service.trafficDistribution | string | `""` | Specify the [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) additional Topology Aware Routing may be informative. Specify the [Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) |
@@ -291,6 +292,7 @@ helm install <RELEASE_NAME> \
 | haproxy.service.ipFamilies | list | `[]` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
 | haproxy.service.ipFamilyPolicy | string | `""` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
 | haproxy.service.loadBalancerIP | string | `""` | Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer). |
+| haproxy.service.loadBalancerSourceRanges | list | `[]` | Specify the [loadBalancerSourceRanges](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service) to restrict client IP ranges that can access the LoadBalancer Service. |
 | haproxy.service.ports | list | `[]` | Manually set HAPRoxy's Service ports, overrides automated generation of Service ports. |
 | haproxy.service.topologyKeys | list | `[]` | Specify the [topologyKeys](https://kubernetes.io/docs/concepts/services-networking/service-topology/#using-service-topology) field on HAProxy's Service spec. |
 | haproxy.service.type | string | `"ClusterIP"` | Set type of HAProxy's Service. |

--- a/charts/vector/templates/haproxy/service.yaml
+++ b/charts/vector/templates/haproxy/service.yaml
@@ -17,6 +17,10 @@ spec:
 {{- if .Values.haproxy.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.haproxy.service.loadBalancerIP }}
 {{- end }}
+{{- with .Values.haproxy.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- if .Values.haproxy.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.haproxy.service.ipFamilyPolicy }}
 {{- end }}

--- a/charts/vector/templates/service.yaml
+++ b/charts/vector/templates/service.yaml
@@ -20,6 +20,10 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}
+{{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
 {{- end }}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -294,6 +294,8 @@ service:
   internalTrafficPolicy: ""
   # service.loadBalancerIP -- Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer).
   loadBalancerIP: ""
+  # service.loadBalancerSourceRanges -- Specify the [loadBalancerSourceRanges](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service) to restrict client IP ranges that can access the LoadBalancer Service.
+  loadBalancerSourceRanges: []
   # service.ipFamilyPolicy -- Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).
   ipFamilyPolicy: ""
   # service.ipFamilies -- Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).
@@ -653,6 +655,8 @@ haproxy:
     externalTrafficPolicy: ""
     # haproxy.service.loadBalancerIP -- Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer).
     loadBalancerIP: ""
+    # haproxy.service.loadBalancerSourceRanges -- Specify the [loadBalancerSourceRanges](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service) to restrict client IP ranges that can access the LoadBalancer Service.
+    loadBalancerSourceRanges: []
     # haproxy.service.ipFamilyPolicy -- Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).
     ipFamilyPolicy: ""
     # haproxy.service.ipFamilies -- Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).


### PR DESCRIPTION
Adds `service.loadBalancerSourceRanges` and `haproxy.service.loadBalancerSourceRanges` so a `type: LoadBalancer` Service can be restricted by client IP, matching the existing `loadBalancerIP` field. Defaults to `[]` (unrestricted) and is only rendered when set.

Tested with `helm template`; `helm lint` passes. Supersedes #485.