### PR TITLE
chore(releasing): Include non-conventional commits in changelog

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -36,9 +36,11 @@ footer = """
 """
 
 [git]
-# allow only conventional commits
-# https://www.conventionalcommits.org
+# parse commits according to the conventional commits specification
 conventional_commits = true
+# keep non-conventional commits instead of dropping them (e.g. merge commits,
+# subjects that do not follow the conventional format)
+filter_unconventional = false
 # regex for parsing and grouping commits
 commit_parsers = [
     { message = "^(feat|enhancement)", group = "Features"},
@@ -47,6 +49,10 @@ commit_parsers = [
     { message = "^perf", group = "Performance"},
     { message = "^refactor", group = "Refactor"},
     { body = ".*security", group = "Security"},
+    { message = "^Merge", skip = true },
+    { message = "^GHA trigger", skip = true },
+    { message = '^chore\(deps', skip = true },
+    { message = ".*", group = "Other", default_scope = "other"},
 ]
 # filter out the commits that are not matched by commit parsers
 filter_commits = true

--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -52,6 +52,8 @@ commit_parsers = [
     { message = "^Merge", skip = true },
     { message = "^GHA trigger", skip = true },
     { message = '^chore\(deps', skip = true },
+    # non-conventional commits need an explicit scope (git-cliff cannot infer it)
+    { message = "selectorLabel", group = "Other", scope = "Vector" },
     { message = ".*", group = "Other", default_scope = "other"},
 ]
 # filter out the commits that are not matched by commit parsers

--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -53,7 +53,7 @@ commit_parsers = [
     { message = "^GHA trigger", skip = true },
     { message = '^chore\(deps', skip = true },
     # non-conventional commits need an explicit scope (git-cliff cannot infer it)
-    { message = "selectorLabel", group = "Other", scope = "Vector" },
+    { message = "selectorLabel", group = "Other", scope = "vector" },
     { message = ".*", group = "Other", default_scope = "other"},
 ]
 # filter out the commits that are not matched by commit parsers


### PR DESCRIPTION
## Why

git-cliff was silently dropping non-conventional commits from the generated
changelog. In the 0.58.0 release, the topologySpreadConstraints change
(e626b5b) was missing until manually added during review. This config change
keeps non-conventional commits in the changelog and scopes them explicitly.

## Testing

Ran `git cliff --config .github/cliff.toml vector-0.57.0..vector-0.58.0` with
both git-cliff 2.7.0 (pinned in the release workflow) and 2.13.1. Output is
byte-identical on both; e626b5b now renders under `### Vector / #### Other`,
and merge/GHA-trigger/dependabot commits remain excluded.

## Does this PR include user facing changes?

No
